### PR TITLE
fix: nest showSetupOnStart under stats.* (build warning)

### DIFF
--- a/data.default.json
+++ b/data.default.json
@@ -68,14 +68,14 @@
     "bestSessionHmRecent": 0,
     "bestOfLast5": -1,
     "buckets": {},
-    "pyramid": ""
+    "pyramid": "",
+    "showSetupOnStart": 0
   },
   "projName1": "",
   "projName2": "",
   "projName3": "",
   "projName4": "",
   "projName5": "",
-  "showSetupOnStart": 0,
   "s0": { "totalRoutes": 0, "totalSends": 0, "sendPct": 0, "sessions": 0, "peakGrade": -1 },
   "s1": { "totalRoutes": 0, "totalSends": 0, "sendPct": 0, "sessions": 0, "peakGrade": -1 },
   "s2": { "totalRoutes": 0, "totalSends": 0, "sendPct": 0, "sessions": 0, "peakGrade": -1 },

--- a/data.json
+++ b/data.json
@@ -68,7 +68,8 @@
     "bestSessionHmRecent": 0,
     "bestOfLast5": -1,
     "buckets": {},
-    "pyramid": ""
+    "pyramid": "",
+    "showSetupOnStart": 0
   },
   "projName1": "",
   "projName2": "",
@@ -144,6 +145,5 @@
     "sendPct": 0,
     "sessions": 0,
     "totalHeight": 0
-  },
-  "showSetupOnStart": 0
+  }
 }

--- a/main.js
+++ b/main.js
@@ -353,8 +353,8 @@ function onLoad(_input, output) {
   currentGrade = DEFAULT_IDX[gradeSystem];
   allTimeStats.sessions++;
   var ws = LS.getObject("watchSetup");
-  var sos = LS.getObject("showSetupOnStart");
-  if (ws && !sos) { state = 0; currentTemplate = "ready"; }
+  var sv = LS.getObject("stats");
+  if (ws && !(sv && sv.showSetupOnStart)) { state = 0; currentTemplate = "ready"; }
 }
 
 function evaluate(input, output) {

--- a/manifest.json
+++ b/manifest.json
@@ -150,7 +150,7 @@
   ],
   "variables": [
     {"shownName": "Current Grade System", "path": "stats.system", "type": "int"},
-    {"shownName": "Show grade-system setup at app start (1=yes, 0=skip)", "path": "showSetupOnStart", "type": "int"},
+    {"shownName": "Show grade-system setup at app start (1=yes, 0=skip)", "path": "stats.showSetupOnStart", "type": "int"},
     {"shownName": "Send Pyramid", "path": "stats.pyramid", "type": "string"},
     {"shownName": "Current System Routes", "path": "stats.totalRoutes", "type": "int"},
     {"shownName": "Current System Sends", "path": "stats.totalSends", "type": "int"},


### PR DESCRIPTION
Top-level int companion vars not supported by Suunto data validator. Moved to stats.showSetupOnStart matching all other int paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)