### PR TITLE
fix: route push in main.js + ext19 per-commit

### DIFF
--- a/ext10.js
+++ b/ext10.js
@@ -1,18 +1,15 @@
-function(lgi,lgs,ld,lha,lmh,lp1,lp3,isSend,cm,bse,bsc,routes,ps,ats,h){
+function(lgi,lgs,ld,lha,lmh,lp1,lp3,isSend,cm,bse,bsc,ps,ats,h){
 var bk={tr:ats.totalRoutes,ts:ats.totalSends,sp:ats.sendPct,bse:bse};
 var sk=cm>0?lgs+"_"+cm:null;
 if(sk){var pe=ps[sk];bk.sk=sk;bk.psp=pe?{a:pe.attempts,s:pe.sends,b:pe.bestTime,f:pe.firstSes,g:pe.g}:null}
 if(isSend){var enc=lgs*100+lgi;
 if(enc>bse){bse=enc;bsc=1;}else if(enc===bse){bsc++;}}
-var fs=0;
+var fs=0,np=null;
 if(sk){
 var isNew=!ps[sk];
 var p=ps[sk]||{attempts:0,sends:0,bestTime:0};
 if(isNew) p.firstSes=ats.sessions;
 p.g=lgi;p.attempts++;
 if(isSend){if(p.sends===0)fs=1;p.sends++;if(p.bestTime===0||ld<p.bestTime)p.bestTime=ld}
-ps[sk]=p;localStorage.setObject("climbProjStats",ps)}
-routes.push({grade:lgi,sys:lgs,duration:ld,send:isSend?1:0,hr:lha,mh:lmh,p1:lp1,p3:lp3,proj:cm,h:h||0,fs:fs});
-ats.totalRoutes++;if(isSend)ats.totalSends++;
-ats.sendPct=Math.round(ats.totalSends*100/ats.totalRoutes);
-return[bse,bk]}
+ps[sk]=p;localStorage.setObject("climbProjStats",ps);np=p}
+return[bse,bk,{grade:lgi,sys:lgs,duration:ld,send:isSend?1:0,hr:lha,mh:lmh,p1:lp1,p3:lp3,proj:cm,h:h||0,fs:fs},sk,np]}

--- a/main.js
+++ b/main.js
@@ -159,13 +159,20 @@ var commitDirty = function(input) {
   if (frDirty) {
     frDirty = 0;
     lastHrAvg = input.A || 0;
-    var lMx = input.M || 0;
     lastDuration = input.D || 0;
     lastPk1 = bestPk1 || lastHrAvg;
     lastPk3 = bestPk3 || lastHrAvg;
-    var r = loadExt(10)(lastGradeIdx, lastGradeSys, lastDuration, lastHrAvg, lMx, lastPk1, lastPk3,
-      frSend, climbMode, bestSendEnc, 0, routes, projStats, allTimeStats, lastHeight);
+    var r = loadExt(10)(lastGradeIdx, lastGradeSys, lastDuration, lastHrAvg, input.M || 0, lastPk1, lastPk3,
+      frSend, climbMode, bestSendEnc, 0, projStats, allTimeStats, lastHeight);
     bestSendEnc = r[0]; lastBk = r[1];
+    if (r[2]) {
+      routes.push(r[2]);
+      allTimeStats.totalRoutes++;
+      if (frSend) allTimeStats.totalSends++;
+      allTimeStats.sendPct = Math.round(allTimeStats.totalSends * 100 / Math.max(1, allTimeStats.totalRoutes));
+      if (r[3] && r[4]) projStats[r[3]] = r[4];
+      LS.setObject("climbRoutes", routes);
+    }
     hrIdx = hr1Sum = hr3Sum = bestPk1 = bestPk3 = 0;
   }
 };

--- a/main.js
+++ b/main.js
@@ -172,6 +172,7 @@ var commitDirty = function(input) {
       allTimeStats.sendPct = Math.round(allTimeStats.totalSends * 100 / Math.max(1, allTimeStats.totalRoutes));
       if (r[3] && r[4]) projStats[r[3]] = r[4];
       LS.setObject("climbRoutes", routes);
+      loadExt(19)(routes, routeNumber, sendsCount);
     }
     hrIdx = hr1Sum = hr3Sum = bestPk1 = bestPk3 = 0;
   }


### PR DESCRIPTION
## Diagnosis from last test
User saw 'NoLS ext9' — meaning ext9 returned its default fallback (no lastSummary in localStorage). Either:
1. onExerciseEnd doesn't fire reliably on Suunto 9 Pro (firmware?), or
2. ext19 crashes silently inside onExerciseEnd context

## Insight from v2.9 (live, working)
v2.9 NEVER called onExerciseEnd. Summary worked because getSummaryOutputs computed values INLINE from main.js state (output.totalSends, output.totalRoutes, bestSendCount). Plus routes.push was in main.js's finishRoute, not in an extN.js sub-context.

## Fix (two parts)

### 1. Route push in main.js (Theory E fix per Codex)
- `ext10.js`: drop routes/ats params, return `[bse, bk, routeObj, sk, np]`
- `main.js commitDirty`: push r[2] into routes, increment allTimeStats, set projStats[r[3]] = r[4], persist routes to localStorage

If evalFile copies args (Theory E) instead of passing by reference, ext10's push never made it back to main.js. Now main.js does the mutation directly.

### 2. Per-commit ext19 (don't trust onExerciseEnd)
- `main.js commitDirty`: also calls `loadExt(19)(routes, routeNumber, sendsCount)` after every route push
- lastSummary is updated continuously — by activity end, always fresh
- onExerciseEnd call kept as backup (also writes ext20 heavy stats)

## Risk
main.js: 12,464B → 12,988B (+524B). v2.9 (proven working on Suunto 9 Pro per user: "alle ganz famos") was 12,078B. We're 910B over v2.9 — might hit parser budget. If max-app warning, we shrink elsewhere.

## Test plan
- [ ] Sync, climb 2 routes, end activity
- [ ] Summary should show `Sends / Routes: X/Y` with real values
- [ ] No `NoLS ext9` or `NoRoutes rn/rl` sentinels
- [ ] If max-app warning instead → revert ext19-per-commit, find smaller path

🤖 Generated with [Claude Code](https://claude.com/claude-code)