### PR TITLE
feat: summary stats + remove discardPop overlay

### DIFF
--- a/break.html
+++ b/break.html
@@ -66,12 +66,6 @@
         ">
   <div id="climblogger">
 
-    <!-- Discard confirm overlay (shown while UP-long is held; full = discard). -->
-    <div id="discardPop" style="position:absolute;top:0;left:0;width:100%;height:100%;
-         background:rgba(0,0,0,0.85);visibility:HIDDEN;z-index:10;">
-      <div class="f-ico p-hc sp-c-red" style="top:calc(50% - 50%e);font-size:80px;">&#xF110;</div>
-    </div>
-
     <!-- Title bar -->
     <div class="cm-fg" style="width:100%;height:16%">
       <div id="title" class="sp-t-s" style="top:calc(50% - 50%e); left:calc(50% - 50%e);">
@@ -179,9 +173,7 @@
     <userInput>
       <pushButton name="up" type="lock" longType="lock" longPressDuration="3"
         onClick="$.put('/Zapp/{zapp_index}/Event', 1, null, 'int32');"
-        onLongPressStart="setStyle('#discardPop','visibility','VISIBLE')"
-        onLongPressCancel="setStyle('#discardPop','visibility','HIDDEN')"
-        onLongPressFull="setStyle('#discardPop','visibility','HIDDEN');$.put('/Zapp/{zapp_index}/Event', 0, null, 'int32');" />
+        onLongPressFull="$.put('/Zapp/{zapp_index}/Event', 0, null, 'int32');" />
       <pushButton name="next" longType="lock"
         onLongPressStart="if(cMode==0)$.put('/Zapp/{zapp_index}/Event', 4, null, 'int32');" />
       <pushButton name="down" type="lock" longType="lock"

--- a/ext19.js
+++ b/ext19.js
@@ -1,18 +1,23 @@
 function(routes,rn,sc){
 var n=routes?routes.length:-1;
-if(!routes||n===0){var d=localStorage.getObject('dbgEnd')||{};localStorage.setObject('lastSummary',[{id:'x',name:'NoRoutes rn/rl',format:'Count_Fourdigits',value:rn|0,postfix:'/ '+(d.rl|0)},{id:'x2',name:'sc/tr',format:'Count_Fourdigits',value:sc|0,postfix:'/ '+(d.tr|0)}]);return}
+if(!routes||n===0){localStorage.setObject('lastSummary',[{id:'sr',name:'Sends / Routes',format:'Count_Fourdigits',value:0,postfix:'/ 0'}]);return}
 var G='3a,3a+,3b,3b+,3c,3c+,4a,4a+,4b,4b+,4c,4c+,5a,5a+,5b,5b+,5c,5c+,6a,6a+,6b,6b+,6c,6c+,7a,7a+,7b,7b+,7c,7c+,8a,8a+,8b,8b+,8c,8c+,9a,9a+,9b,9b+,9c|4,4+,5-,5,5+,6-,6,6+,7-,7,7+,8-,8,8+,9-,9,9+,10-,10,10+,11-,11,11+,12-|5.5,5.6,5.7,5.8,5.9,5.10a,5.10b,5.10c,5.10d,5.11a,5.11b,5.11c,5.11d,5.12a,5.12b,5.12c,5.12d,5.13a,5.13b,5.13c,5.13d,5.14a,5.14b,5.14c,5.14d,5.15a,5.15b,5.15c,5.15d|4a,4b,4c,5a,5b,5c,6a,6b,6c,7a,7b|VB,V0,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12|4A,4A+,4B,4B+,4C,4C+,5A,5A+,5B,5B+,5C,5C+,6A,6A+,6B,6B+,6C,6C+,7A,7A+,7B,7B+,7C,7C+,8A,8A+,8B,8B+,8C,8C+|WI2,WI3,WI3+,WI4,WI4+,WI5,WI5+,WI6,WI6+,WI7,WI7+|M1,M2,M3,M4,M5,M6,M7,M8,M9,M10,M11,M12|Set|Lap'.split('|');
 var LENS=[41,24,29,11,14,30,11,12,1,1];
 function nm(e){if(e<0)return -1;var L=LENS[Math.floor(e/100)];return L>1?(e%100)/(L-1):0}
 function dG(x){var si=Math.floor(x/100);return x>=0&&si>=0&&si<=9?(x%100>=50?'OFF':(G[si]||'').split(',')[x%100]||'?'):'--'}
-var r=n,s=0,ht=0,sp=-1,spC=0,hrSum=0,hrCnt=0;
+var r=n,s=0,ht=0,sp=-1,spC=0,hp=-1,dur=0,hrSum=0,hrCnt=0;
 for(var i=0;i<r;i++){var rr=routes[i];
-if(rr.send){s++;var enc=rr.sys*100+rr.grade;if(nm(enc)>nm(sp)){sp=enc;spC=1}else if(enc===sp)spC++}
+var enc=rr.sys*100+rr.grade;
+if(nm(enc)>nm(hp))hp=enc;
+if(rr.send){s++;if(nm(enc)>nm(sp)){sp=enc;spC=1}else if(enc===sp)spC++}
 if(rr.h>0)ht+=rr.h;
+if(rr.duration>0)dur+=rr.duration;
 if(rr.hr>0){hrSum+=rr.hr;hrCnt++}}
 var htR=Math.round(ht);
 var out=[{id:'sr',name:'Sends / Routes',format:'Count_Fourdigits',value:s,postfix:'/ '+r}];
 if(sp>=0)out.push({id:'b',name:'Highest Send',format:'Count_Fourdigits',value:spC,postfix:'* '+dG(sp)});
+if(hp>=0&&hp!==sp)out.push({id:'t',name:'Hardest Try',format:'Count_Fourdigits',value:1,postfix:dG(hp)});
+if(dur>0)out.push({id:'d',name:'Climb Time',format:'Duration_FourdigitsFixed',value:dur});
 if(hrCnt>0)out.push({id:'a',name:'Avg HR',format:'HeartRate_Fourdigits',value:hrSum/hrCnt});
 if(ht>0)out.push({id:'h',name:'Height',format:'Count_Fourdigits',value:htR,postfix:'m'});
 localStorage.setObject('lastSummary',out);

--- a/main.js
+++ b/main.js
@@ -391,7 +391,6 @@ function onExerciseEnd(input, output) {
     routeNumber++;
   }
   commitDirty(input || {});
-  LS.setObject("dbgEnd", { st: state, rn: routeNumber, fr: frDirty, sc: sendsCount, rl: routes.length, tr: allTimeStats.totalRoutes });
   loadExt(19)(routes, routeNumber, sendsCount);
   loadExt(20)(routes, allTimeStats, projStats, gradeSystem);
   setOutputs(output);


### PR DESCRIPTION
## Issues addressed
1. ✅ Summary now works (PR #50). Adding more useful stats.
2. 🔴 Red thick circle in middle of break screen → was the discardPop overlay's 80px F110 icon. On Suunto 9 Pro the F110 PUA codepoint renders as a thick filled circle rather than X. Removed the overlay.

## Changes

### Summary screen — added stats
- **Climb Time** — sum of all route durations (Duration_FourdigitsFixed format)
- **Hardest Try** — highest grade *attempted* regardless of send (only shown if different from Highest Send → useful for project days where you push but don't send)

Final summary items (in order, conditional):
- Sends / Routes (always)
- Highest Send (if any send)
- Hardest Try (if different from Highest Send)
- Climb Time (if any duration)
- Avg HR (if HR data)
- Height (if any ascent)

### Break screen — removed discardPop
- `<div id="discardPop">` with 80px red F110 icon removed
- pushButton up still has `onLongPressFull` → discard event (works without visual feedback during hold)
- The X-pill top-right remains as a small visual hint that discard is possible
- User had said earlier "the symbol is enough" so they accept no in-progress overlay

### Cleanup
- Removed now-redundant `dbgEnd` localStorage write from onExerciseEnd (summary works via per-commit write; debug sentinel no longer needed)

## Sizes
- main.js: 12,988B → **12,851B** (-137B)
- break.html: 12,233B → **11,467B** (-766B)
- ext19.js: 2,026B → **2,143B** (+117B for new stats)

## Test plan
- [ ] Climb 2 routes (mix of send + fail), end activity
- [ ] Summary should show: Sends/Routes, Highest Send (if any send), Hardest Try (if any fail at higher grade), Climb Time
- [ ] Break screen: no red circle in middle anymore
- [ ] UP-long-hold 3s still discards last route

🤖 Generated with [Claude Code](https://claude.com/claude-code)