### PR TITLE
feat: showSetupOnStart default ON

### DIFF
--- a/data.default.json
+++ b/data.default.json
@@ -69,7 +69,7 @@
     "bestOfLast5": -1,
     "buckets": {},
     "pyramid": "",
-    "showSetupOnStart": 0
+    "showSetupOnStart": 1
   },
   "projName1": "",
   "projName2": "",

--- a/data.json
+++ b/data.json
@@ -69,7 +69,7 @@
     "bestOfLast5": -1,
     "buckets": {},
     "pyramid": "",
-    "showSetupOnStart": 0
+    "showSetupOnStart": 1
   },
   "projName1": "",
   "projName2": "",


### PR DESCRIPTION
Setup screen now shows on every app start by default. Companion toggle still works (0 = skip). Closes the 'I have to dig into companion to see the system selector again' UX issue.