### PR TITLE
fix: onExerciseEnd error (event 1024 crash)

### DIFF
--- a/main.js
+++ b/main.js
@@ -382,18 +382,15 @@ function evaluate(input, output) {
   setOutputs(output);
 }
 
-function onExerciseEnd(input, output) {
-  if (input && input.Asc !== undefined) curAsc = input.Asc;
+function onExerciseEnd(input, _output) {
   if (state === 1) {
-    lastResult = 0; lastGradeIdx = currentGrade; lastGradeSys = gradeSystem;
+    lastGradeIdx = currentGrade; lastGradeSys = gradeSystem;
     lastHeight = Math.max(0, Math.round(curAsc - startAsc));
     frDirty = 1; frSend = 0;
     routeNumber++;
   }
   commitDirty(input || {});
-  loadExt(19)(routes, routeNumber, sendsCount);
   loadExt(20)(routes, allTimeStats, projStats, gradeSystem);
-  setOutputs(output);
 }
 
 function onEvent(_input, output, eventId) {


### PR DESCRIPTION
## Diagnosis from watch log
`ERR APPLICATION : Zapp climbl01:run evt 1024` — Event 1024 is onExerciseEnd. My code threw inside it.

Most likely cause: `setOutputs(output)` writes many `output.X` fields. Memory note `feedback_outputs_evaluate_only.md` documented this for `onLoad` — same restriction probably applies to `onExerciseEnd` since it also runs near app shutdown.

## Fix
Removed `setOutputs(output)` from onExerciseEnd. Also dropped dead code:
- Bare `input.Asc` read (`input` is undefined in dispatched function context after minification)
- Redundant `loadExt(19)` call (already called per-commit in commitDirty)
- Unused `lastResult = 0` assignment

## Why summary still works
ext19 is called from `commitDirty` per-route. By activity end, `lastSummary` in localStorage is already populated. `getSummaryOutputs` reads it via slim ext9.

## ext20 (heavy stats)
Still called once in onExerciseEnd for gradeHistory/peakGrade/bestOfLast5 updates. ext20 doesn't write `output.X` (only localStorage), should be safe. If it errors too, will move to per-commit.

## Sizes
- main.js: 12,851B → **12,703B** (-148B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)