### PR TITLE
feat: move discard from break to session-edit (3-state cycle)

### DIFF
--- a/break.html
+++ b/break.html
@@ -132,16 +132,7 @@
       <span class="sp-b-s f-num" id="hrr" style="padding-left:3px">--</span>
     </div>
 
-    <!-- Top-button: visible pill (X = discard via UP-long-hold 3s). -->
-    <div style="top:18%;left:83%;width:15%;height:12%;position:absolute;">
-      <div style="top:0; left:0; width:100%;height:100%;position:absolute;
-                  background:rgba(255,255,255,0.15);
-                  border-radius:40% 0 0 40%;">
-        <div class="f-ico cm-bgc"
-             style="top:calc(55% - 50%e); left:6px;">&#xF110;</div>
-      </div>
-    </div>
-    <!-- Top-button: tap zone removed (discard is UP-long-hold only; no touch path). -->
+    <!-- Top-button: no UP-long action on break — discard moved to session-edit screen -->
 
     <!-- Down-button: visible pill (fixed size). -->
     <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;">
@@ -173,8 +164,7 @@
     <:if test="{{ HAS_ON_EVENT }}">
     <userInput>
       <pushButton name="up" type="lock" longType="lock"
-        onClick="$.put('/Zapp/{zapp_index}/Event', 1, null, 'int32');"
-        onLongPressStart="$.put('/Zapp/{zapp_index}/Event', 0, null, 'int32');" />
+        onClick="$.put('/Zapp/{zapp_index}/Event', 1, null, 'int32');" />
       <pushButton name="next" longType="lock"
         onLongPressStart="if(cMode==0)$.put('/Zapp/{zapp_index}/Event', 4, null, 'int32');" />
       <pushButton name="down" type="lock" longType="lock"

--- a/main.js
+++ b/main.js
@@ -24,12 +24,12 @@ var lastGradeIdx = -1;
 var lastGradeSys = 0;
 var lastHrAvg = 0;
 var bestSendEnc = -1;
-var lastBk = null;
 var frDirty = 0;
 var frSend = 0;
 var selfLapExpected = 0;
 var editIdx = 0;
 var editDirty = 0;
+var editDelMark = 0;
 var isPaused = 0;
 
 var climbMode = 0;
@@ -87,7 +87,7 @@ var setOutputs = function(output) {
     output.lastGrade = rr.sys !== undefined ? encGrade(rr.sys, rr.grade) : -1;
     output.routeNum = routes.length > 0 ? editIdx + 1 : 0;
     output.modeSub = routes.length;
-    output.editSend = rr.send || 0;
+    output.editSend = editDelMark ? 2 : (rr.send || 0);
   } else if (state === 4) {
     output.grade = encGrade(gradeSystem, DEFAULT_IDX[gradeSystem]);
     output.modeSub = gradeSystem;
@@ -169,7 +169,7 @@ var commitDirty = function(input) {
     lastPk3 = bestPk3 || lastHrAvg;
     var r = loadExt(10)(lastGradeIdx, lastGradeSys, lastDuration, lastHrAvg, hrMax || (input.M || 0), lastPk1, lastPk3,
       frSend, climbMode, bestSendEnc, 0, projStats, allTimeStats, lastHeight);
-    bestSendEnc = r[0]; lastBk = r[1];
+    bestSendEnc = r[0];
     if (r[2]) {
       routes.push(r[2]);
       allTimeStats.totalRoutes++;
@@ -246,27 +246,6 @@ var evBreak = function(output, eid, dy) {
     saveAsProject(output);
   } else if (eid === 6 && !frDirty) {
     goState(0, "ready", output);
-  } else if (eid === 0) {
-    if (frDirty) {
-      frDirty = 0;
-    } else if (lastBk) {
-      routes.pop();
-      allTimeStats.totalRoutes = lastBk.tr;
-      allTimeStats.totalSends = lastBk.ts;
-      allTimeStats.sendPct = lastBk.sp;
-      if (lastBk.sk) {
-        if (lastBk.psp) {
-          projStats[lastBk.sk] = { attempts: lastBk.psp.a, sends: lastBk.psp.s, bestTime: lastBk.psp.b, firstSes: lastBk.psp.f, g: lastBk.psp.g };
-        } else {
-          delete projStats[lastBk.sk];
-        }
-        LS.setObject("climbProjStats", projStats);
-      }
-      bestSendEnc = lastBk.bse;
-    }
-    if (frSend) sendsCount--;
-    routeNumber--;
-    goState(0, "ready", output);
   }
 };
 
@@ -300,14 +279,38 @@ var evProjSetup = function(output, eid) {
 var evEdit = function(output, eid) {
   var n = routes.length;
   if (eid === 4 || eid === 7 || eid === 12) {
+    if (editDelMark) {
+      var dr = routes[editIdx];
+      if (dr) {
+        allTimeStats.totalRoutes--;
+        if (dr.send) { allTimeStats.totalSends--; if (sendsCount > 0) sendsCount--; }
+        allTimeStats.sendPct = allTimeStats.totalRoutes > 0 ? Math.round(allTimeStats.totalSends * 100 / allTimeStats.totalRoutes) : 0;
+        if (dr.proj > 0) {
+          var dk = dr.sys + "_" + dr.proj, dp = projStats[dk];
+          if (dp) {
+            if (dp.attempts > 0) dp.attempts--;
+            if (dr.send && dp.sends > 0) dp.sends--;
+            if (dp.attempts <= 0) delete projStats[dk]; else projStats[dk] = dp;
+          }
+        }
+        routes.splice(editIdx, 1);
+        LS.setObject("climbRoutes", routes);
+        recalcBse();
+        n = routes.length;
+        if (editIdx >= n && n > 0) editIdx = n - 1;
+      }
+      editDelMark = 0;
+      editDirty = 1;
+    }
     if (editDirty) { LS.setObject("climbProjStats", projStats); writeStats(); editDirty = 0; }
-    if (eid === 12) {
-      if (n > 0) editIdx = (editIdx - 1 + n) % n;
+    if (eid === 12 && n > 0) {
+      editIdx = (editIdx - 1 + n) % n;
       var pr = routes[editIdx];
       if (pr) {
         output.lastGrade = encGrade(pr.sys, pr.grade);
         output.editSend = pr.send || 0;
         output.routeNum = editIdx + 1;
+        output.modeSub = n;
       }
     } else {
       goState(0, "ready", output);
@@ -315,25 +318,38 @@ var evEdit = function(output, eid) {
     return;
   }
   if (n === 0) return;
-  if (eid === 5) editIdx = (editIdx + 1) % n;
-  else if (eid === 6) editIdx = (editIdx - 1 + n) % n;
+  if (eid === 5) { editIdx = (editIdx + 1) % n; editDelMark = 0; }
+  else if (eid === 6) { editIdx = (editIdx - 1 + n) % n; editDelMark = 0; }
   else if (eid === 3) {
     var r = routes[editIdx];
     if (r) {
-      r.send = r.send ? 0 : 1;
-      if (r.send) { sendsCount++; allTimeStats.totalSends++; }
-      else { sendsCount--; allTimeStats.totalSends--; }
-      allTimeStats.sendPct = Math.round(allTimeStats.totalSends * 100 / Math.max(1, allTimeStats.totalRoutes));
-      if (r.proj > 0) {
-        var k = r.sys + "_" + r.proj, p = projStats[k];
-        if (p) {
-          if (r.send) p.sends++;
-          else if (p.sends > 0) p.sends--;
+      if (editDelMark) {
+        editDelMark = 0;
+        r.send = 0;
+        if (sendsCount > 0) sendsCount--;
+        allTimeStats.totalSends--;
+        if (r.proj > 0) {
+          var k = r.sys + "_" + r.proj, p = projStats[k];
+          if (p && p.sends > 0) p.sends--;
         }
+        output.editSend = 0;
+      } else if (r.send) {
+        editDelMark = 1;
+        output.editSend = 2;
+      } else {
+        r.send = 1;
+        sendsCount++;
+        allTimeStats.totalSends++;
+        if (r.proj > 0) {
+          var k2 = r.sys + "_" + r.proj, p2 = projStats[k2];
+          if (p2) p2.sends++;
+        }
+        output.editSend = 1;
       }
+      allTimeStats.sendPct = Math.round(allTimeStats.totalSends * 100 / Math.max(1, allTimeStats.totalRoutes));
       recalcBse();
-      output.editSend = r.send;
       output.bestSend = bestSendEnc;
+      editDirty = 1;
     }
   } else if (eid === 1 || eid === 2) {
     var rr = routes[editIdx];

--- a/session.html
+++ b/session.html
@@ -4,11 +4,33 @@
           var G='3a,3a+,3b,3b+,3c,3c+,4a,4a+,4b,4b+,4c,4c+,5a,5a+,5b,5b+,5c,5c+,6a,6a+,6b,6b+,6c,6c+,7a,7a+,7b,7b+,7c,7c+,8a,8a+,8b,8b+,8c,8c+,9a,9a+,9b,9b+,9c|4,4+,5-,5,5+,6-,6,6+,7-,7,7+,8-,8,8+,9-,9,9+,10-,10,10+,11-,11,11+,12-|5.5,5.6,5.7,5.8,5.9,5.10a,5.10b,5.10c,5.10d,5.11a,5.11b,5.11c,5.11d,5.12a,5.12b,5.12c,5.12d,5.13a,5.13b,5.13c,5.13d,5.14a,5.14b,5.14c,5.14d,5.15a,5.15b,5.15c,5.15d|4a,4b,4c,5a,5b,5c,6a,6b,6c,7a,7b|VB,V0,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12|4A,4A+,4B,4B+,4C,4C+,5A,5A+,5B,5B+,5C,5C+,6A,6A+,6B,6B+,6C,6C+,7A,7A+,7B,7B+,7C,7C+,8A,8A+,8B,8B+,8C,8C+|WI2,WI3,WI3+,WI4,WI4+,WI5,WI5+,WI6,WI6+,WI7,WI7+|M1,M2,M3,M4,M5,M6,M7,M8,M9,M10,M11,M12|Set|Lap'.split('|');
           function dG(x){return x>=0?(x%100>=50?'OFF':(G[Math.floor(x/100)]||'').split(',')[x%100]||'?'):'--'}
           $.subscribe('/Zapp/{zapp_index}/Output/editSend',function(v){
-            setText('#resIco',String.fromCharCode(v?0xF200:0xF110));
-            setText('#resLbl',v?'SEND':'FAIL');
-            setStyle('#resIco','color',v?'#5cdd8b':'#ff6666');
-            setText('#midIco',String.fromCharCode(v?0xF110:0xF200));
-            setStyle('#midIco','color',v?'#ff6666':'#5cdd8b');
+            if(v===2){
+              setStyle('#resIco','visibility','HIDDEN');
+              setText('#resLbl','DEL');
+              setStyle('#resLbl','color','#ffa500');
+              setStyle('#midIco','visibility','VISIBLE');
+              setStyle('#midTxt','visibility','HIDDEN');
+              setText('#midIco',String.fromCharCode(0xF110));
+              setStyle('#midIco','color','#ff6666');
+            }else if(v===1){
+              setStyle('#resIco','visibility','VISIBLE');
+              setText('#resIco',String.fromCharCode(0xF200));
+              setStyle('#resIco','color','#5cdd8b');
+              setText('#resLbl','SEND');
+              setStyle('#resLbl','color','#FFFFFF');
+              setStyle('#midIco','visibility','HIDDEN');
+              setStyle('#midTxt','visibility','VISIBLE');
+            }else{
+              setStyle('#resIco','visibility','VISIBLE');
+              setText('#resIco',String.fromCharCode(0xF110));
+              setStyle('#resIco','color','#ff6666');
+              setText('#resLbl','FAIL');
+              setStyle('#resLbl','color','#FFFFFF');
+              setStyle('#midIco','visibility','VISIBLE');
+              setStyle('#midTxt','visibility','HIDDEN');
+              setText('#midIco',String.fromCharCode(0xF200));
+              setStyle('#midIco','color','#5cdd8b');
+            }
           });
         ">
   <div id="climblogger">
@@ -56,13 +78,15 @@
     <div onTap="$.put('/Zapp/{zapp_index}/Event', 7, null, 'int32');"
       style="top:11%;left:70%;width:30%;height:25%;position:absolute;"></div>
 
-    <!-- Middle pill: shows OPPOSITE of current SEND/FAIL state (preview of toggle) -->
+    <!-- Middle pill: cycle preview — icon (SEND/FAIL) or text (DEL) for next cycle state -->
     <div style="top:44%;left:90%;width:10%;height:12%;position:absolute;">
       <div style="top:0; left:0; width:100%;height:100%;position:absolute;
                   background:rgba(255,255,255,0.15);
                   border-radius:40% 0 0 40%;">
         <div id="midIco" class="f-ico"
              style="top:calc(55% - 50%e); left:6px;">&#xF200;</div>
+        <div id="midTxt" class="sp-b-s"
+             style="top:calc(55% - 50%e); left:4px;visibility:HIDDEN;color:#ffa500;font-size:11px;">DEL</div>
       </div>
     </div>
     <div onTap="$.put('/Zapp/{zapp_index}/Event', 3, null, 'int32');"


### PR DESCRIPTION
## Change
Discard moved off break screen (no more UP-long-press conflict with system) onto session-edit screen as a 3rd state in the send/fail toggle cycle.

## UX
Mid-long-press cycles: **FAIL → SEND → DEL → FAIL ...**

- FAIL state: red X icon + 'FAIL' label, mid-pill previews next (SEND icon green)
- SEND state: green ✓ icon + 'SEND' label, mid-pill previews next ('DEL' text orange)
- DEL state: hidden icon + 'DEL' label orange, mid-pill previews next (FAIL X icon red)

When user presses save (UP-long event 7 or DOWN-long event 12, or pill tap), if editDelMark is set, the route is actually deleted (routes.splice + stats undo + projStats decrement + localStorage update).

## Code
- main.js: +593B (3-state cycle logic + inline delete-on-save block; removed evBreak event 0 + lastBk)
- break.html: -535B (no X-pill, no UP-long handler)
- session.html: +1,214B (new subscribe + #midTxt element, all lazy-loaded)

## Budget warning
main.js at 13,752B. v2.9 was 12,078B (proven working). +1,674B over baseline. If max-app warning, will need to shrink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)