### PR TITLE
fix: routeNumber after delete (ready showed wrong route count)

### DIFF
--- a/main.js
+++ b/main.js
@@ -296,6 +296,7 @@ var evEdit = function(output, eid) {
         routes.splice(editIdx, 1);
         LS.setObject("climbRoutes", routes);
         recalcBse();
+        if (routeNumber > 1) routeNumber--;
         n = routes.length;
         if (editIdx >= n && n > 0) editIdx = n - 1;
       }


### PR DESCRIPTION
User report: after deleting route 1 of 3 in edit screen, ready still showed 'ROUTE 3'. routeNumber counter wasn't decremented on delete. Fixed with single line. Guard against going below 1.