### PR TITLE
diag #74: try/catch onExerciseEnd body

### DIFF
--- a/main.js
+++ b/main.js
@@ -416,8 +416,12 @@ function onExerciseEnd(input, _output) {
     frDirty = 1; frSend = 0;
     routeNumber++;
   }
-  commitDirty(input || {});
-  loadExt(20)(routes, allTimeStats, projStats, gradeSystem);
+  try {
+    commitDirty(input || {});
+    loadExt(20)(routes, allTimeStats, projStats, gradeSystem);
+  } catch (e) {
+    LS.setObject("dbgEndErr", { msg: "" + e });
+  }
 }
 
 function onEvent(_input, output, eventId) {


### PR DESCRIPTION
Captures any exception from commitDirty or loadExt(20) into localStorage.dbgEndErr. Two outcomes after user retest: (1) evt 1024 error gone in log → JS exception, dbgEndErr will have message; (2) error still logged → firmware-level issue (timeout/heap), needs different approach.