### PR TITLE
chore: integrate zappsim into per-commit workflow + npm validate script

### DIFF
--- a/main.js
+++ b/main.js
@@ -407,7 +407,7 @@ function onLoad(_input, output) {
   var ws = LS.getObject("watchSetup");
   var sv = LS.getObject("stats");
   if (ws && !(sv && sv.showSetupOnStart)) { state = 0; currentTemplate = "cm"; }
-  // NEVER call setOutputs(output) here — output.xxx writes in onLoad cause "max app" crash on Vertical 2.
+  // NEVER call setOutputs here — writes to the output object in onLoad cause "max app" crash on Vertical 2.
   // vState gets published when evaluate() runs setOutputs (first tick = 1s after load).
 }
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "suuntoplus-climb-logger",
+  "version": "3.0",
+  "description": "Suunto Watch climbing logger app — dev validation scripts via zappsim",
+  "private": true,
+  "scripts": {
+    "validate": "node ../zappsim/bin/zappsim.js validate .",
+    "test:session-end": "node ../zappsim/bin/zappsim.js run . --scenario session-end-flow",
+    "test:cycle-edit": "node ../zappsim/bin/zappsim.js run . --scenario cycle-edit-routes",
+    "test:rapid-stress": "node ../zappsim/bin/zappsim.js run . --scenario rapid-stress",
+    "test:template-cycle": "node ../zappsim/bin/zappsim.js run . --scenario template-cycle"
+  }
+}


### PR DESCRIPTION
## Summary
Make zappsim static analysis a mandatory step before every commit/PR. Add convenience npm scripts in repo root.

## Changes
- **package.json** (new): exposes `npm run validate` + scenario test commands
- **main.js:410** comment reword: fix false-positive OUTPUT_REFERENCED_NOT_IN_MANIFEST regex match on the word "output.xxx" in a comment
- **memory/workflow_session_pr_pattern.md**: workflow updated (lives in Claude user memory, not in repo)

## Workflow update
```bash
npm run validate     # PFLICHT before commit
npm run test:session-end   # optional scenario run
```

Exit codes:
- 0 = PASS → commit OK
- 1 = FAIL → fix or document as known-false-positive
- 2 = setup error

## Known-acceptable findings (v3.0 single-template)
- \`SUBSCRIBE_IN_HTML_ONLOAD\` cm.html:18 — single-template architecture (cm.html never reloads during session) = no leak risk. Acceptable.
- \`PARSER_BUDGET_RISKY\` main.js:1 — 16 KB in untested 13.98-18 KB band. Watch-tested OK; no max-app crash.

## Test plan
- [x] \`npm run validate\` runs zappsim static check
- [x] Result: 1 fail (documented FP), 1 warn (documented) — workflow accepts
- [x] False-positive on line 410 (comment text) fixed by reword

🤖 Generated with [Claude Code](https://claude.com/claude-code)