### PR TITLE
fix #87: skip writeStats() in projSetup save&back (HardFault mitigation)

### DIFF
--- a/main.js
+++ b/main.js
@@ -292,7 +292,10 @@ var evProjSetup = function(output, eid, dy) {
     output.grade = projGradeIdx[pStep] >= 0 ? encGrade(gradeSystem, projGradeIdx[pStep]) : encGrade(gradeSystem, 50);
     output.modeSub = pStep + 1;
   } else if (eid === 5) {
-    saveAll();
+    // #87: skip writeStats() — ext11 evalFile in UI-task while WB path-resolver saturated
+    // caused IBUSERR HardFault → Bootloop. Persist watchSetup only; stats sync via onExerciseEnd.
+    allProjects[gradeSystem] = projGradeIdx.slice();
+    try { LS.setObject("watchSetup", { sys: gradeSystem, proj: allProjects }); } catch (e) {}
     goState(0, "cm", output);
   } else if (eid === 6) {
     pStep = (pStep + 1) % 5;


### PR DESCRIPTION
## Summary

- Isolated fix for [#87](https://github.com/wylandplex/suuntoplus-climb-logger/issues/87) — IBUSERR HardFault → Bootloop triggered by `ext11.js evalFile` in UI-task while WB path-resolver was saturated.
- `evProjSetup` save&back now persists `watchSetup` directly (the only thing the user actually changed in this screen) and defers the heavy `writeStats()` to `onExerciseEnd`.
- Does NOT touch [#86](https://github.com/wylandplex/suuntoplus-climb-logger/issues/86) (route-edit freeze) — that's a different mechanism (output burst on state transition, no ext11 trigger) and needs its own targeted fix tested in isolation per `feedback_test_individually` memory rule.

## Crash evidence

`logging/log.log` from the 2026-05-19 watch test (3 zapps: climbl01 + zzcalien + zzaeroen, ~20 routes logged):

```
12:21:47  EVT UI_FRAMEWORK : evalFile: b:/zapp/climbl01.fea/ext11.js from ui
12:21:51  ERR FAULT : HardFault (task:ui)
12:21:51  ERR FAULT : HFSR:  0x40000000   (FORCED)
12:21:51  ERR FAULT : CFSR:  0x01000000   (IBUSERR — instruction bus error)
12:21:51  ERR FAULT : R12:   0x3D3D3D3D   (stack-corruption pattern '====')
12:21:51  EVT BOOTLOOP : Faultcom c:fa017c01
12:21:51  TRC APPLICATION : Start wuiapp 2.53.42 in mode 5
```

ext11.js was loaded twice this session. First time at 12:20:39 survived. Second time at 12:21:47 — after additional WB-path-resolver overflows accumulated heap fragmentation — faulted. Trigger: `loadExt(11)` in `writeStats()` called from `saveAll()` in `evProjSetup` save&back at [main.js:294-296](main.js).

## Why this fix specifically

Three options were considered (Phase 1 mitigations 0a, 0b, 0c from the abandoned v3.0.3 branch — see [project_multi_app_freeze memory file](https://github.com/wylandplex/suuntoplus-climb-logger/issues/87#issuecomment-4487136934)):

- **A (this PR)** — skip `writeStats()` in projSetup save&back. Smallest possible change. Eliminates the exact `evalFile ext11.js from ui` trigger that preceded the HardFault by 4 seconds.
- B — also defer the 16-output `setOutputs()` burst via `goState(0, "cm", null)`. Would also address #86 but mixes two changes.
- C — also lightweight-ify `evEdit` save&back. Adds a second behavioural change without isolated test signal.

Picked A alone for clear test signal — if the next watch-test reproduces #87 with this fix in, we know writeStats wasn't the root cause and need to revisit. If it doesn't repro, we have a clean answer.

## Trade-off accepted

If the user changes `projGradeIdx` and then the activity ends abnormally (battery / HardFault from a different bug / force-shutdown) before `onExerciseEnd` runs, the `stats.p<gs>_<idx>` snapshot stays at its previous value while `watchSetup.proj[gs][idx]` reflects the new value. On the next App-Load, [ext12.js](ext12.js) reads watchSetup *first* but then overrides with `stats.p<gs>_<idx>` if defined — so the old value wins. Net effect: user loses their project-edit changes after a crash.

This is acceptable because:
1. The HardFault we're fixing here WAS the dominant source of abnormal-ends in this session.
2. Clean Activity ends (the happy path) run `writeStats()` via `onExerciseEnd` and everything stays in sync.
3. Battery-empty during a climb session is rare; users who change project grades typically do it once at session start.

A follow-up could fix ext12's priority ordering (watchSetup should win over stats.p-keys) but that's a separate concern.

## What changed

```diff
   } else if (eid === 5) {
-    saveAll();
+    // #87: skip writeStats() — ext11 evalFile in UI-task while WB path-resolver saturated
+    // caused IBUSERR HardFault → Bootloop. Persist watchSetup only; stats sync via onExerciseEnd.
+    allProjects[gradeSystem] = projGradeIdx.slice();
+    try { LS.setObject("watchSetup", { sys: gradeSystem, proj: allProjects }); } catch (e) {}
     goState(0, "cm", output);
   } else if (eid === 6) {
```

Size impact: main.js 16007 → 16336 B (+329 B). Still in the 13,980–18,000 risky band — same status as before, no new parser-budget alert.

## Test plan

- [ ] Rebuild `climbl01-q.fea` via VS Code SuuntoPlus extension (mandatory — repo doesn't auto-build .fea)
- [ ] Watch test on Suunto Vertical 2 with 2-3 zapps active (climbl01 + zzcalien + zzaeroen reproduces the original)
- [ ] Log ~15-20 routes
- [ ] Enter project-edit screen, change a project grade, save&back → verify no freeze, no reboot
- [ ] Repeat several times to stress-test
- [ ] Pull `logging/log.log` after — confirm:
  - No `evalFile: b:/zapp/climbl01.fea/ext11.js from ui` during evProjSetup save (only at onLoad and onExerciseEnd)
  - No `HardFault` or `BOOTLOOP` entries
  - Path-overflow `res:2129` may still appear (separate issue, #86)
- [ ] After clean Activity end: verify summary shows correct stats and per-system snapshots updated

## Not addressed in this PR

- [#86](https://github.com/wylandplex/suuntoplus-climb-logger/issues/86) — route-edit freeze (output burst, not ext11 trigger) → needs separate PR
- WB path-resolver saturation itself — architectural, needs ADR-002 revisit. Will reduce frequency by removing one heavy LS+evalFile sequence but won't eliminate.
- ext12.js stale-stats override behavior — see Trade-off section above

🤖 Generated with [Claude Code](https://claude.com/claude-code)