### PR TITLE
fix(#91): cache loadExt(14) — eliminate per-saveAsProject ext14 re-parse

### DIFF
--- a/main.js
+++ b/main.js
@@ -49,7 +49,7 @@ var DEFAULT_IDX = [18, 6, 5, 5, 4, 12, 3, 5, 0, 0];
 var gradeSystem = 0;
 var LS = localStorage;
 var loadExt = function(n) { return evalFile('{file_path}/ext' + n + '.js'); };
-var f10, f11, f17;  // T7: cache parsed ext fns; per-route re-parse was heap-fragmenting
+var f10, f11, f14, f17;  // T7/T9: cache parsed ext fns; per-route re-parse was heap-fragmenting
 
 function getUserInterface() {
   return { template: currentTemplate };
@@ -183,7 +183,7 @@ var toggleMode = function() {
 };
 
 var saveAsProject = function(output) {
-  var r = loadExt(14)(climbMode, gradeSystem, lastGradeSys, lastGradeIdx, lastResult, lastDuration, allProjects, projGradeIdx, projStats, routes, allTimeStats.sessions);
+  var r = f14(climbMode, gradeSystem, lastGradeSys, lastGradeIdx, lastResult, lastDuration, allProjects, projGradeIdx, projStats, routes, allTimeStats.sessions);
   if (r) {
     gradeSystem = r[0]; currentGrade = r[1]; climbMode = r[2];
     saveAll();
@@ -419,7 +419,7 @@ var evEdit = function(output, eid) {
 };
 
 function onLoad(_input, output) {
-  f10 = loadExt(10); f11 = loadExt(11); f17 = loadExt(17);  // T7: cache once
+  f10 = loadExt(10); f11 = loadExt(11); f14 = loadExt(14); f17 = loadExt(17);  // T7/T9: cache once
   var r = loadExt(12)(allTimeStats, allProjects, GRADE_LENS);
   gradeSystem = r[0];
   allProjects = r[1];


### PR DESCRIPTION
## Summary

T9 follow-up to v2.98 T7 cached ext fns. `saveAsProject` previously re-parsed `ext14.js` on every MID-long press in BREAK. Adds `f14 = loadExt(14)` to onLoad and replaces the in-line `loadExt(14)(...)` call with `f14(...)`.

main.js: 17127 → 17149 B (+22 B). Still under 18 KB max-app threshold.

## Test plan

- [ ] zappsim validate (already PASS for this change; pre-existing #90 fail unchanged)
- [ ] Watch-test on Suunto Vertical 2: enter BREAK after a route, MID-long-press to saveAsProject, confirm no \"max app\" warning, no freeze, project stats appear correctly
- [ ] Multi-app scenario: run several saveAsProject in a row, verify heap stable (was the next vulnerable trigger after T7)

Closes #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)