### PR TITLE
fix(#90): replace leaky $.subscribe in cm.html onLoad with <eval> binding

### DIFF
--- a/cm.html
+++ b/cm.html
@@ -23,7 +23,8 @@
   <div id="climblogger">
 
     <!-- vState → applyVis: <eval> binding replaces leaky $.subscribe (#90). Eval bindings are framework-managed, do not leak on template unload. -->
-    <div style="display:none"><eval input="/Zapp/{zapp_index}/Output/vState" outputFormat="script x => applyVis(x)" default="" /></div>
+    <!-- SuuntoPlus CSS parser rejects display:none → use visibility:HIDDEN + 0-dim instead. -->
+    <div style="position:absolute;top:0;left:0;width:0;height:0;visibility:HIDDEN"><eval input="/Zapp/{zapp_index}/Output/vState" outputFormat="script x => (applyVis(x),'')" default="" /></div>
 
     <!-- Grauer Rombus-Hintergrund für die Bottom-Time-Bar (auf jedem Screen sichtbar) -->
     <div style="position:absolute;top:84%;left:15%;width:70%;height:14%;background:rgba(255,255,255,0.15);clip-path:polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);"></div>

--- a/cm.html
+++ b/cm.html
@@ -15,13 +15,15 @@
             setStyle('#sc5','visibility',x===5?'VISIBLE':'HIDDEN');
             setStyle('#sc6','visibility',x===6?'VISIBLE':'HIDDEN');
           }
-          $.subscribe('/Zapp/{zapp_index}/Output/vState',applyVis);
           function ev(n){$.put('/Zapp/{zapp_index}/Event',n,null,'int32')}
           function lap(){$.put('/Activity/Trigger',23)}
           function evX(n){if(lock)return;ev(n);lock=1}
           function evL(n){if(lock)return;ev(n);if((n===6&&lapState===0)||lapState===1){lap();lock=1}}
         ">
   <div id="climblogger">
+
+    <!-- vState → applyVis: <eval> binding replaces leaky $.subscribe (#90). Eval bindings are framework-managed, do not leak on template unload. -->
+    <div style="display:none"><eval input="/Zapp/{zapp_index}/Output/vState" outputFormat="script x => applyVis(x)" default="" /></div>
 
     <!-- Grauer Rombus-Hintergrund für die Bottom-Time-Bar (auf jedem Screen sichtbar) -->
     <div style="position:absolute;top:84%;left:15%;width:70%;height:14%;background:rgba(255,255,255,0.15);clip-path:polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);"></div>


### PR DESCRIPTION
## Summary

Replaces `\$.subscribe('/Zapp/.../Output/vState', applyVis)` in `cm.html` onLoad with a hidden `<eval>` binding. Subscribers in template onLoad leak (no unsubscribe on template unload); eval bindings are framework-managed and don't leak.

In v3.0's single-template architecture the leak is theoretical (template never unloads), but it remains a fail in zappsim and a defensive risk if architecture ever switches to multi-template.

## Changes

- Remove `\$.subscribe(...)` line from cm.html onLoad
- Add hidden `<div><eval input=\"/Zapp/{zapp_index}/Output/vState\" outputFormat=\"script x => applyVis(x)\" /></div>` near top of climblogger div

`applyVis` stays in cm.html scope (still needed for `lapState`/`lock` used by `evL`).

WB load: 35 → 36 paths (+1 eval binding). Well under V2 ~80-path limit.

## Test plan

- [x] zappsim validate: 1 fail → 0 fails (only parser-budget warning remains)
- [ ] Watch-test on Suunto Vertical 2:
  - [ ] State transitions work (READY → CLIMB → BREAK → READY etc.) — visibility changes correctly
  - [ ] sc4 (setup) and sc5 (edit) visibility transitions work
  - [ ] No initial-state visibility regression (sc0 should be VISIBLE on app launch, others HIDDEN)

Closes #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)