### PR TITLE
fix(#92): lazy single-system grade cache (supersedes eager pre-split)

### DIFF
--- a/cm.html
+++ b/cm.html
@@ -3,7 +3,8 @@
         onLoad="
           var G='3a,3a+,3b,3b+,3c,3c+,4a,4a+,4b,4b+,4c,4c+,5a,5a+,5b,5b+,5c,5c+,6a,6a+,6b,6b+,6c,6c+,7a,7a+,7b,7b+,7c,7c+,8a,8a+,8b,8b+,8c,8c+,9a,9a+,9b,9b+,9c|4,4+,5-,5,5+,6-,6,6+,7-,7,7+,8-,8,8+,9-,9,9+,10-,10,10+,11-,11,11+,12-|5.5,5.6,5.7,5.8,5.9,5.10a,5.10b,5.10c,5.10d,5.11a,5.11b,5.11c,5.11d,5.12a,5.12b,5.12c,5.12d,5.13a,5.13b,5.13c,5.13d,5.14a,5.14b,5.14c,5.14d,5.15a,5.15b,5.15c,5.15d|4a,4b,4c,5a,5b,5c,6a,6b,6c,7a,7b|VB,V0,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12|4A,4A+,4B,4B+,4C,4C+,5A,5A+,5B,5B+,5C,5C+,6A,6A+,6B,6B+,6C,6C+,7A,7A+,7B,7B+,7C,7C+,8A,8A+,8B,8B+,8C,8C+|WI2,WI3,WI3+,WI4,WI4+,WI5,WI5+,WI6,WI6+,WI7,WI7+|M1,M2,M3,M4,M5,M6,M7,M8,M9,M10,M11,M12|Set|Lap'.split('|');
           var SN='French Sport,UIAA Sport,YDS Sport,British Trad,V-Scale,Font Boulder,Ice (WI),Mixed (M),Hangboard,Scrambling'.split(',');
-          function dG(x){return x>=0?(x%100>=50?'OFF':(G[Math.floor(x/100)]||'').split(',')[x%100]||'?'):'--'}
+          var Gs=null,Gsi=-1;
+          function dG(x){if(x<0)return'--';if(x%100>=50)return'OFF';var si=Math.floor(x/100);if(si!==Gsi){Gs=(G[si]||'').split(',');Gsi=si}return(Gs||[])[x%100]||'?'}
           function sN(x){return SN[x]||'?'}
           var lapState=4,lock=0;
           function applyVis(x){


### PR DESCRIPTION
## Summary

Replaces buggy eager pre-split-all-grade-systems (closed PR #98) with lazy single-system cache.

User domain insight: grade-system is FIXED per activity. So only one grade-system needs splitting at any moment.

```js
var Gs = null, Gsi = -1;
function dG(x){
  if(x < 0) return '--';
  if(x % 100 >= 50) return 'OFF';
  var si = Math.floor(x / 100);
  if(si !== Gsi){ Gs = (G[si] || '').split(','); Gsi = si; }
  return (Gs || [])[x % 100] || '?';
}
```

## zappsim heap (rapid-stress, 100 routes)

| Version | Peak |
|---------|------|
| master | 98.0% |
| **this branch** | **98.3%** (+0.3) |
| eager pre-split (PR #98) | 101.7% ❌ |

## Test plan

- [ ] Flash isolated, no other v2.99 fixes
- [ ] 50+ routes session — verify no relMemCb, no overlap
- [ ] UP/DOWN grade cycling — verify snappy after first cycle

Closes #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)