### PR TITLE
fix(#93): snapshot lapState + reorder lap()/ev() (isolated)

### DIFF
--- a/cm.html
+++ b/cm.html
@@ -19,7 +19,7 @@
           function ev(n){$.put('/Zapp/{zapp_index}/Event',n,null,'int32')}
           function lap(){$.put('/Activity/Trigger',23)}
           function evX(n){if(lock)return;ev(n);lock=1}
-          function evL(n){if(lock)return;ev(n);if((n===6&&lapState===0)||lapState===1){lap();lock=1}}
+          function evL(n){if(lock)return;var s=lapState;if((n===6&&s===0)||s===1){lap();lock=1}ev(n)}
         ">
   <div id="climblogger">
 


### PR DESCRIPTION
## Summary

evL snapshots lapState before any \$.put, fires lap() FIRST (based on snapshot), then ev() for state change. Eliminates the documented race in #93.

## What this is

Part of original PR #99 split out for individual bisect-testing. Standalone — works without the other #89/#93 fixes.

## Mechanism

Original:
```js
function evL(n){if(lock)return;ev(n);if((n===6&&lapState===0)||lapState===1){lap();lock=1}}
//                              ^ ev() can fire applyVis sync, mutating lapState before check
```

Fixed:
```js
function evL(n){if(lock)return;var s=lapState;if((n===6&&s===0)||s===1){lap();lock=1}ev(n)}
//                              ^ snapshot first   ^ lap based on snapshot   ^ state change last
```

## zappsim heap

| Version | Peak |
|---------|------|
| master | 98.0% |
| **this branch** | **98.0%** (0) |

Zero heap impact — pure logic fix.

## Test plan

- [ ] Flash isolated
- [ ] Verify lap markers appear on every CLIMB→BREAK and READY→CLIMB transition
- [ ] Fast-click sequence — no silent lap drops

Refs #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)