### PR TITLE
fix: ext19 LS-write removal — prevent summary card drop

### DIFF
--- a/ext19.js
+++ b/ext19.js
@@ -1,6 +1,6 @@
 function(routes,rn,sc){
 var n=routes?routes.length:-1;
-if(!routes||n===0){var ph=[{id:'sr',name:'Sends / Routes',format:'Count_Fourdigits',value:0,postfix:'/ 0'}];localStorage.setObject('lastSummary',ph);return ph}
+if(!routes||n===0)return[{id:'sr',name:'Sends / Routes',format:'Count_Fourdigits',value:0,postfix:'/ 0'}];
 var G='3a,3a+,3b,3b+,3c,3c+,4a,4a+,4b,4b+,4c,4c+,5a,5a+,5b,5b+,5c,5c+,6a,6a+,6b,6b+,6c,6c+,7a,7a+,7b,7b+,7c,7c+,8a,8a+,8b,8b+,8c,8c+,9a,9a+,9b,9b+,9c|4,4+,5-,5,5+,6-,6,6+,7-,7,7+,8-,8,8+,9-,9,9+,10-,10,10+,11-,11,11+,12-|5.5,5.6,5.7,5.8,5.9,5.10a,5.10b,5.10c,5.10d,5.11a,5.11b,5.11c,5.11d,5.12a,5.12b,5.12c,5.12d,5.13a,5.13b,5.13c,5.13d,5.14a,5.14b,5.14c,5.14d,5.15a,5.15b,5.15c,5.15d|4a,4b,4c,5a,5b,5c,6a,6b,6c,7a,7b|VB,V0,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12|4A,4A+,4B,4B+,4C,4C+,5A,5A+,5B,5B+,5C,5C+,6A,6A+,6B,6B+,6C,6C+,7A,7A+,7B,7B+,7C,7C+,8A,8A+,8B,8B+,8C,8C+|WI2,WI3,WI3+,WI4,WI4+,WI5,WI5+,WI6,WI6+,WI7,WI7+|M1,M2,M3,M4,M5,M6,M7,M8,M9,M10,M11,M12|Set|Lap'.split('|');
 function dG(x){var si=Math.floor(x/100);return x>=0&&si>=0&&si<=9?(x%100>=50?'OFF':(G[si]||'').split(',')[x%100]||'?'):'--'}
 var s=0,ht=0,sp=-1,spC=0,hp=-1,dur=0,hrSum=0,hrCnt=0;
@@ -17,6 +17,4 @@ if(hp>=0&&hp!==sp)out.push({id:'t',name:'Hardest Try',format:'Count_Fourdigits',
 if(dur>0)out.push({id:'d',name:'Climb Time',format:'Duration_FourdigitsFixed',value:dur});
 if(hrCnt>0)out.push({id:'a',name:'Avg HR',format:'HeartRate_Fourdigits',value:hrSum/hrCnt});
 if(ht>0)out.push({id:'h',name:'Height',format:'Count_Fourdigits',value:htR,postfix:'m'});
-localStorage.setObject('lastSummary',out);
-localStorage.setObject('_sumTmp',{sp:sp,htR:htR});
 return out}


### PR DESCRIPTION
## Summary

Removes the 3 LS.setObject calls from ext19.js. They violated main.js comment at line 495:
> SUMMARY ONLY — no LS writes here (heap pressure can hang ext11 parse and lose the summary entirely)

User watch-test 2026-05-19: 5-6 route cycling session, ext19 fired correctly but summary card was NOT shown. Root cause: LS writes in ex-saving timing window block on flash I/O → firmware times out waiting for getSummaryOutputs return.

## Side effect

ext9 fallback ('remember last session summary on next activity start') is no longer updated. If important, can be re-added in main.js onExerciseEnd in a separate PR (initial attempt did this but added too many bytes, was reverted).

## zappsim heap

| Version | Peak |
|---------|------|
| master | 98.0% |
| **this branch** | **98.0%** (0) |

Zero impact — removal only.

## Test plan

- [ ] Flash isolated
- [ ] Do 5+ route session
- [ ] At activity end, verify summary card appears (Sends/Routes, Highest Send, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)