### PR TITLE
feat: ADR-003 completion bundle (4 fixes, no cooldown/dwell)

### DIFF
--- a/cm.html
+++ b/cm.html
@@ -23,7 +23,8 @@
   <div id="climblogger">
 
     <!-- vState → applyVis: <eval> binding replaces leaky $.subscribe (#90). Eval bindings are framework-managed, do not leak on template unload. -->
-    <div style="display:none"><eval input="/Zapp/{zapp_index}/Output/vState" outputFormat="script x => applyVis(x)" default="" /></div>
+    <!-- SuuntoPlus CSS parser rejects display:none → use visibility:HIDDEN + 0-dim instead. -->
+    <div style="position:absolute;top:0;left:0;width:0;height:0;visibility:HIDDEN"><eval input="/Zapp/{zapp_index}/Output/vState" outputFormat="script x => (applyVis(x),'')" default="" /></div>
 
     <!-- Grauer Rombus-Hintergrund für die Bottom-Time-Bar (auf jedem Screen sichtbar) -->
     <div style="position:absolute;top:84%;left:15%;width:70%;height:14%;background:rgba(255,255,255,0.15);clip-path:polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);"></div>

--- a/cm.html
+++ b/cm.html
@@ -19,7 +19,7 @@
           function ev(n){$.put('/Zapp/{zapp_index}/Event',n,null,'int32')}
           function lap(){$.put('/Activity/Trigger',23)}
           function evX(n){if(lock)return;ev(n);lock=1}
-          function evL(n){if(lock)return;ev(n);if((n===6&&lapState===0)||lapState===1){lap();lock=1}}
+          function evL(n){if(lock)return;var s=lapState;if((n===6&&s===0)||s===1){lap();lock=1}ev(n)}
         ">
   <div id="climblogger">
 

--- a/cm.html
+++ b/cm.html
@@ -3,7 +3,8 @@
         onLoad="
           var G='3a,3a+,3b,3b+,3c,3c+,4a,4a+,4b,4b+,4c,4c+,5a,5a+,5b,5b+,5c,5c+,6a,6a+,6b,6b+,6c,6c+,7a,7a+,7b,7b+,7c,7c+,8a,8a+,8b,8b+,8c,8c+,9a,9a+,9b,9b+,9c|4,4+,5-,5,5+,6-,6,6+,7-,7,7+,8-,8,8+,9-,9,9+,10-,10,10+,11-,11,11+,12-|5.5,5.6,5.7,5.8,5.9,5.10a,5.10b,5.10c,5.10d,5.11a,5.11b,5.11c,5.11d,5.12a,5.12b,5.12c,5.12d,5.13a,5.13b,5.13c,5.13d,5.14a,5.14b,5.14c,5.14d,5.15a,5.15b,5.15c,5.15d|4a,4b,4c,5a,5b,5c,6a,6b,6c,7a,7b|VB,V0,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12|4A,4A+,4B,4B+,4C,4C+,5A,5A+,5B,5B+,5C,5C+,6A,6A+,6B,6B+,6C,6C+,7A,7A+,7B,7B+,7C,7C+,8A,8A+,8B,8B+,8C,8C+|WI2,WI3,WI3+,WI4,WI4+,WI5,WI5+,WI6,WI6+,WI7,WI7+|M1,M2,M3,M4,M5,M6,M7,M8,M9,M10,M11,M12|Set|Lap'.split('|');
           var SN='French Sport,UIAA Sport,YDS Sport,British Trad,V-Scale,Font Boulder,Ice (WI),Mixed (M),Hangboard,Scrambling'.split(',');
-          function dG(x){return x>=0?(x%100>=50?'OFF':(G[Math.floor(x/100)]||'').split(',')[x%100]||'?'):'--'}
+          var Gs=null,Gsi=-1;
+          function dG(x){if(x<0)return'--';if(x%100>=50)return'OFF';var si=Math.floor(x/100);if(si!==Gsi){Gs=(G[si]||'').split(',');Gsi=si}return(Gs||[])[x%100]||'?'}
           function sN(x){return SN[x]||'?'}
           var lapState=4,lock=0;
           function applyVis(x){

--- a/cm.html
+++ b/cm.html
@@ -15,13 +15,15 @@
             setStyle('#sc5','visibility',x===5?'VISIBLE':'HIDDEN');
             setStyle('#sc6','visibility',x===6?'VISIBLE':'HIDDEN');
           }
-          $.subscribe('/Zapp/{zapp_index}/Output/vState',applyVis);
           function ev(n){$.put('/Zapp/{zapp_index}/Event',n,null,'int32')}
           function lap(){$.put('/Activity/Trigger',23)}
           function evX(n){if(lock)return;ev(n);lock=1}
           function evL(n){if(lock)return;ev(n);if((n===6&&lapState===0)||lapState===1){lap();lock=1}}
         ">
   <div id="climblogger">
+
+    <!-- vState → applyVis: <eval> binding replaces leaky $.subscribe (#90). Eval bindings are framework-managed, do not leak on template unload. -->
+    <div style="display:none"><eval input="/Zapp/{zapp_index}/Output/vState" outputFormat="script x => applyVis(x)" default="" /></div>
 
     <!-- Grauer Rombus-Hintergrund für die Bottom-Time-Bar (auf jedem Screen sichtbar) -->
     <div style="position:absolute;top:84%;left:15%;width:70%;height:14%;background:rgba(255,255,255,0.15);clip-path:polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);"></div>

--- a/ext19.js
+++ b/ext19.js
@@ -1,6 +1,6 @@
 function(routes,rn,sc){
 var n=routes?routes.length:-1;
-if(!routes||n===0){var ph=[{id:'sr',name:'Sends / Routes',format:'Count_Fourdigits',value:0,postfix:'/ 0'}];localStorage.setObject('lastSummary',ph);return ph}
+if(!routes||n===0)return[{id:'sr',name:'Sends / Routes',format:'Count_Fourdigits',value:0,postfix:'/ 0'}];
 var G='3a,3a+,3b,3b+,3c,3c+,4a,4a+,4b,4b+,4c,4c+,5a,5a+,5b,5b+,5c,5c+,6a,6a+,6b,6b+,6c,6c+,7a,7a+,7b,7b+,7c,7c+,8a,8a+,8b,8b+,8c,8c+,9a,9a+,9b,9b+,9c|4,4+,5-,5,5+,6-,6,6+,7-,7,7+,8-,8,8+,9-,9,9+,10-,10,10+,11-,11,11+,12-|5.5,5.6,5.7,5.8,5.9,5.10a,5.10b,5.10c,5.10d,5.11a,5.11b,5.11c,5.11d,5.12a,5.12b,5.12c,5.12d,5.13a,5.13b,5.13c,5.13d,5.14a,5.14b,5.14c,5.14d,5.15a,5.15b,5.15c,5.15d|4a,4b,4c,5a,5b,5c,6a,6b,6c,7a,7b|VB,V0,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12|4A,4A+,4B,4B+,4C,4C+,5A,5A+,5B,5B+,5C,5C+,6A,6A+,6B,6B+,6C,6C+,7A,7A+,7B,7B+,7C,7C+,8A,8A+,8B,8B+,8C,8C+|WI2,WI3,WI3+,WI4,WI4+,WI5,WI5+,WI6,WI6+,WI7,WI7+|M1,M2,M3,M4,M5,M6,M7,M8,M9,M10,M11,M12|Set|Lap'.split('|');
 function dG(x){var si=Math.floor(x/100);return x>=0&&si>=0&&si<=9?(x%100>=50?'OFF':(G[si]||'').split(',')[x%100]||'?'):'--'}
 var s=0,ht=0,sp=-1,spC=0,hp=-1,dur=0,hrSum=0,hrCnt=0;
@@ -17,6 +17,4 @@ if(hp>=0&&hp!==sp)out.push({id:'t',name:'Hardest Try',format:'Count_Fourdigits',
 if(dur>0)out.push({id:'d',name:'Climb Time',format:'Duration_FourdigitsFixed',value:dur});
 if(hrCnt>0)out.push({id:'a',name:'Avg HR',format:'HeartRate_Fourdigits',value:hrSum/hrCnt});
 if(ht>0)out.push({id:'h',name:'Height',format:'Count_Fourdigits',value:htR,postfix:'m'});
-localStorage.setObject('lastSummary',out);
-localStorage.setObject('_sumTmp',{sp:sp,htR:htR});
 return out}


### PR DESCRIPTION
## Summary

Combines the 4 SAFEST v2.99 fixes that align with ADR-003 principles:
- #90 eval-binding for vState (PR #97)
- #92 lazy single-system grade cache (PR #105)
- #93 lap snapshot+reorder (PR #107)
- ext19 LS-write removal (PR #109)

**Excluded** (have heap cost):
- #89 cooldown (small +0.2% heap)
- #89 CLIMB dwell (+0.5% heap + 193B main.js)

This is the conservative \"v2.99 candidate\" — should be flash-tested as a unit IF all 4 individuals pass watch-test.

## zappsim heap

| Version | Peak | main.js |
|---------|------|---------|
| master | 98.0% | 17127 B |
| **this bundle** | **98.3%** (+0.3) | 17127 B (unchanged) |

## Test plan

Only flash this AFTER all 4 individual PRs (#97, #105, #107, #109) pass watch-test.

- [ ] 50+ route session — verify no relMemCb, no overlap, summary card present
- [ ] Fast-click cycles — no lap drops, no '--' on BREAK avg/max
- [ ] State transitions across all 6 screens — visibility correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)