### PR TITLE
feat: v2.99 all safe fixes — full bundle (6 fixes, suspected crash)

### DIFF
--- a/cm.html
+++ b/cm.html
@@ -7,7 +7,7 @@
           function sN(x){return SN[x]||'?'}
           var lapState=4,lock=0;
           function applyVis(x){
-            lapState=x;lock=0;
+            lapState=x;
             setStyle('#sc0','visibility',x===0?'VISIBLE':'HIDDEN');
             setStyle('#sc1','visibility',x===1?'VISIBLE':'HIDDEN');
             setStyle('#sc2','visibility',x===2?'VISIBLE':'HIDDEN');
@@ -18,8 +18,9 @@
           $.subscribe('/Zapp/{zapp_index}/Output/vState',applyVis);
           function ev(n){$.put('/Zapp/{zapp_index}/Event',n,null,'int32')}
           function lap(){$.put('/Activity/Trigger',23)}
-          function evX(n){if(lock)return;ev(n);lock=1}
-          function evL(n){if(lock)return;ev(n);if((n===6&&lapState===0)||lapState===1){lap();lock=1}}
+          function ulk(){lock=0}
+          function evX(n){if(lock)return;ev(n);lock=1;setTimeout(ulk,300)}
+          function evL(n){if(lock)return;ev(n);lock=1;setTimeout(ulk,300);if((n===6&&lapState===0)||lapState===1)lap()}
         ">
   <div id="climblogger">
 

--- a/cm.html
+++ b/cm.html
@@ -23,7 +23,8 @@
   <div id="climblogger">
 
     <!-- vState → applyVis: <eval> binding replaces leaky $.subscribe (#90). Eval bindings are framework-managed, do not leak on template unload. -->
-    <div style="display:none"><eval input="/Zapp/{zapp_index}/Output/vState" outputFormat="script x => applyVis(x)" default="" /></div>
+    <!-- SuuntoPlus CSS parser rejects display:none → use visibility:HIDDEN + 0-dim instead. -->
+    <div style="position:absolute;top:0;left:0;width:0;height:0;visibility:HIDDEN"><eval input="/Zapp/{zapp_index}/Output/vState" outputFormat="script x => (applyVis(x),'')" default="" /></div>
 
     <!-- Grauer Rombus-Hintergrund für die Bottom-Time-Bar (auf jedem Screen sichtbar) -->
     <div style="position:absolute;top:84%;left:15%;width:70%;height:14%;background:rgba(255,255,255,0.15);clip-path:polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);"></div>

--- a/cm.html
+++ b/cm.html
@@ -19,7 +19,7 @@
           function ev(n){$.put('/Zapp/{zapp_index}/Event',n,null,'int32')}
           function lap(){$.put('/Activity/Trigger',23)}
           function evX(n){if(lock)return;ev(n);lock=1}
-          function evL(n){if(lock)return;ev(n);if((n===6&&lapState===0)||lapState===1){lap();lock=1}}
+          function evL(n){if(lock)return;var s=lapState;if((n===6&&s===0)||s===1){lap();lock=1}ev(n)}
         ">
   <div id="climblogger">
 

--- a/cm.html
+++ b/cm.html
@@ -3,7 +3,8 @@
         onLoad="
           var G='3a,3a+,3b,3b+,3c,3c+,4a,4a+,4b,4b+,4c,4c+,5a,5a+,5b,5b+,5c,5c+,6a,6a+,6b,6b+,6c,6c+,7a,7a+,7b,7b+,7c,7c+,8a,8a+,8b,8b+,8c,8c+,9a,9a+,9b,9b+,9c|4,4+,5-,5,5+,6-,6,6+,7-,7,7+,8-,8,8+,9-,9,9+,10-,10,10+,11-,11,11+,12-|5.5,5.6,5.7,5.8,5.9,5.10a,5.10b,5.10c,5.10d,5.11a,5.11b,5.11c,5.11d,5.12a,5.12b,5.12c,5.12d,5.13a,5.13b,5.13c,5.13d,5.14a,5.14b,5.14c,5.14d,5.15a,5.15b,5.15c,5.15d|4a,4b,4c,5a,5b,5c,6a,6b,6c,7a,7b|VB,V0,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12|4A,4A+,4B,4B+,4C,4C+,5A,5A+,5B,5B+,5C,5C+,6A,6A+,6B,6B+,6C,6C+,7A,7A+,7B,7B+,7C,7C+,8A,8A+,8B,8B+,8C,8C+|WI2,WI3,WI3+,WI4,WI4+,WI5,WI5+,WI6,WI6+,WI7,WI7+|M1,M2,M3,M4,M5,M6,M7,M8,M9,M10,M11,M12|Set|Lap'.split('|');
           var SN='French Sport,UIAA Sport,YDS Sport,British Trad,V-Scale,Font Boulder,Ice (WI),Mixed (M),Hangboard,Scrambling'.split(',');
-          function dG(x){return x>=0?(x%100>=50?'OFF':(G[Math.floor(x/100)]||'').split(',')[x%100]||'?'):'--'}
+          var Gs=null,Gsi=-1;
+          function dG(x){if(x<0)return'--';if(x%100>=50)return'OFF';var si=Math.floor(x/100);if(si!==Gsi){Gs=(G[si]||'').split(',');Gsi=si}return(Gs||[])[x%100]||'?'}
           function sN(x){return SN[x]||'?'}
           var lapState=4,lock=0;
           function applyVis(x){

--- a/cm.html
+++ b/cm.html
@@ -15,13 +15,15 @@
             setStyle('#sc5','visibility',x===5?'VISIBLE':'HIDDEN');
             setStyle('#sc6','visibility',x===6?'VISIBLE':'HIDDEN');
           }
-          $.subscribe('/Zapp/{zapp_index}/Output/vState',applyVis);
           function ev(n){$.put('/Zapp/{zapp_index}/Event',n,null,'int32')}
           function lap(){$.put('/Activity/Trigger',23)}
           function evX(n){if(lock)return;ev(n);lock=1}
           function evL(n){if(lock)return;ev(n);if((n===6&&lapState===0)||lapState===1){lap();lock=1}}
         ">
   <div id="climblogger">
+
+    <!-- vState → applyVis: <eval> binding replaces leaky $.subscribe (#90). Eval bindings are framework-managed, do not leak on template unload. -->
+    <div style="display:none"><eval input="/Zapp/{zapp_index}/Output/vState" outputFormat="script x => applyVis(x)" default="" /></div>
 
     <!-- Grauer Rombus-Hintergrund für die Bottom-Time-Bar (auf jedem Screen sichtbar) -->
     <div style="position:absolute;top:84%;left:15%;width:70%;height:14%;background:rgba(255,255,255,0.15);clip-path:polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);"></div>

--- a/ext19.js
+++ b/ext19.js
@@ -1,6 +1,6 @@
 function(routes,rn,sc){
 var n=routes?routes.length:-1;
-if(!routes||n===0){var ph=[{id:'sr',name:'Sends / Routes',format:'Count_Fourdigits',value:0,postfix:'/ 0'}];localStorage.setObject('lastSummary',ph);return ph}
+if(!routes||n===0)return[{id:'sr',name:'Sends / Routes',format:'Count_Fourdigits',value:0,postfix:'/ 0'}];
 var G='3a,3a+,3b,3b+,3c,3c+,4a,4a+,4b,4b+,4c,4c+,5a,5a+,5b,5b+,5c,5c+,6a,6a+,6b,6b+,6c,6c+,7a,7a+,7b,7b+,7c,7c+,8a,8a+,8b,8b+,8c,8c+,9a,9a+,9b,9b+,9c|4,4+,5-,5,5+,6-,6,6+,7-,7,7+,8-,8,8+,9-,9,9+,10-,10,10+,11-,11,11+,12-|5.5,5.6,5.7,5.8,5.9,5.10a,5.10b,5.10c,5.10d,5.11a,5.11b,5.11c,5.11d,5.12a,5.12b,5.12c,5.12d,5.13a,5.13b,5.13c,5.13d,5.14a,5.14b,5.14c,5.14d,5.15a,5.15b,5.15c,5.15d|4a,4b,4c,5a,5b,5c,6a,6b,6c,7a,7b|VB,V0,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12|4A,4A+,4B,4B+,4C,4C+,5A,5A+,5B,5B+,5C,5C+,6A,6A+,6B,6B+,6C,6C+,7A,7A+,7B,7B+,7C,7C+,8A,8A+,8B,8B+,8C,8C+|WI2,WI3,WI3+,WI4,WI4+,WI5,WI5+,WI6,WI6+,WI7,WI7+|M1,M2,M3,M4,M5,M6,M7,M8,M9,M10,M11,M12|Set|Lap'.split('|');
 function dG(x){var si=Math.floor(x/100);return x>=0&&si>=0&&si<=9?(x%100>=50?'OFF':(G[si]||'').split(',')[x%100]||'?'):'--'}
 var s=0,ht=0,sp=-1,spC=0,hp=-1,dur=0,hrSum=0,hrCnt=0;
@@ -17,6 +17,4 @@ if(hp>=0&&hp!==sp)out.push({id:'t',name:'Hardest Try',format:'Count_Fourdigits',
 if(dur>0)out.push({id:'d',name:'Climb Time',format:'Duration_FourdigitsFixed',value:dur});
 if(hrCnt>0)out.push({id:'a',name:'Avg HR',format:'HeartRate_Fourdigits',value:hrSum/hrCnt});
 if(ht>0)out.push({id:'h',name:'Height',format:'Count_Fourdigits',value:htR,postfix:'m'});
-localStorage.setObject('lastSummary',out);
-localStorage.setObject('_sumTmp',{sp:sp,htR:htR});
 return out}

--- a/main.js
+++ b/main.js
@@ -33,6 +33,7 @@ var editDirty = 0;
 var editDelMark = 0;
 var isPaused = 0;
 var pStep = 0;
+var dwell = 0;  // CLIMB-entry guard — cleared at end of next evaluate tick
 
 var climbMode = 0;
 var curAsc = 0;
@@ -144,6 +145,7 @@ var goState = function(s, t, output) {
   var tChanged = (currentTemplate !== t);
   currentTemplate = t;
   if (tChanged) unload('_cm');
+  if (s === 1) dwell = 1;
   if (output) setOutputs(output);
   if (s === 0) {
     pushActStats();
@@ -454,6 +456,7 @@ function evaluate(input, output) {
   // Skip setOutputs in edit (5) — eval-script churn in session.html bindings is OOM-risky at high routes.
   // state=4 (setup) needs it to publish vState so cm.html applyVis fires correctly on initial entry.
   if (state !== 5) setOutputs(output);
+  dwell = 0;
 }
 
 function onExerciseEnd(input, _output) {
@@ -470,6 +473,7 @@ function onExerciseEnd(input, _output) {
 
 function onEvent(_input, output, eventId) {
   if (isPaused) return;
+  if (dwell && state === 1 && (eventId === 5 || eventId === 6)) return;
   var dy = eventId === 1 ? 1 : eventId === 2 ? -1 : 0;
   if (state === 0 || state === 1 || state === 2) {
     if (eventId === 7) dy = 3;


### PR DESCRIPTION
## Summary

Full v2.99 bundle = all 6 fixes including main.js CLIMB dwell. This is essentially what was in release/v2.99 HEAD before the crash investigation (without the reverted onExerciseEnd cache write).

Includes:
- #90 eval-binding (PR #97)
- #92 lazy cache (PR #105)
- #89 cooldown (PR #106)
- #89 CLIMB dwell (PR #108)
- #93 snapshot+reorder (PR #107)
- ext19 LS-write removal (PR #109)

## ⚠ Suspected to crash

User watch-test of essentially this bundle (release/v2.99 HEAD `96712a5`) showed setup→ready immediate crash. This branch is included for diagnostic isolation — if the simpler bundle PR (feat/adr-003-completion) works but THIS one crashes, the CLIMB dwell is the culprit.

## zappsim heap

| Version | Peak | main.js |
|---------|------|---------|
| master | 98.0% | 17127 B |
| **this bundle** | **98.9%** (+0.9) | **17320 B** (+193) |

## Test plan

Only flash AFTER feat/adr-003-completion-plus-cooldown passes. If THIS crashes but cooldown one works → CLIMB dwell is the trigger.

- [ ] Setup → save&exit → verify NO immediate crash
- [ ] If crash → revert CLIMB dwell, document as a 'cannot combine with X' constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)