### PR TITLE
docs: v2.99 bisect test plan for 2026-05-20

### DIFF
--- a/TEST_PLAN_2026-05-20.md
+++ b/TEST_PLAN_2026-05-20.md
@@ -1,0 +1,69 @@
+# v2.99 Bisect Test Plan — 2026-05-20
+
+Watch-test plan for tomorrow morning. Goal: identify which v2.99 change(s) cause the setup→ready crash that surfaced on 2026-05-19 22:38+.
+
+## Baseline
+
+- **master** = v2.98 (already released, watch-verified stable, 80+ routes multi-app)
+- Flash from master to confirm stable baseline if uncertain
+
+## Hypothesis
+
+User watch-test of `release/v2.99` HEAD `96712a5` (= 6 v2.99 fixes combined, minus #91) showed setup→save&exit immediate crash. zappsim couldn't reproduce — all individual fixes safe (≤ 0.5% heap delta vs master). Suspected: combined cumulative heap + parser-budget pressure pushes real watch over edge.
+
+## Phase 1 — Isolated branches (single fix each)
+
+Flash each ONCE, do quick smoke test (setup → save&exit → 2-3 routes). Mark pass/fail.
+
+| Branch | What | PR | zappsim peak | main.js | Result |
+|--------|------|----|--------------|---------|--------|
+| `fix/90-applyvis-eval-binding` | vState eval-binding instead of `$.subscribe` | [#97](https://github.com/wylandplex/suuntoplus-climb-logger/pull/97) | 98.0% | 17127 B | [ ] |
+| `fix/92-lazy-cache` | Lazy single-system grade cache for `dG()` | [#105](https://github.com/wylandplex/suuntoplus-climb-logger/pull/105) | 98.3% | 17127 B | [ ] |
+| `fix/89-cooldown` | 300ms inter-click cooldown via `setTimeout(ulk, 300)` | [#106](https://github.com/wylandplex/suuntoplus-climb-logger/pull/106) | 98.2% | 17127 B | [ ] |
+| `fix/89-climb-dwell` | main.js dwell var + 3 guards in goState/onEvent/evaluate | [#108](https://github.com/wylandplex/suuntoplus-climb-logger/pull/108) | 98.5% | **17320 B** | [ ] |
+| `fix/93-snapshot-reorder` | Snapshot `lapState` + reorder `lap()` before `ev()` in evL | [#107](https://github.com/wylandplex/suuntoplus-climb-logger/pull/107) | 98.0% | 17127 B | [ ] |
+| `fix/ext19-no-ls-writes` | Remove 3 `LS.setObject` from ext19.js (fixes summary-card drop) | [#109](https://github.com/wylandplex/suuntoplus-climb-logger/pull/109) | 98.0% | 17127 B | [ ] |
+
+For each:
+1. `git checkout <branch>` in VS Code
+2. Build .fea via SuuntoPlus Editor
+3. Flash to watch
+4. Test: open app (setup screen) → press DOWN-long-press → expect ready screen
+5. If crash → mark fail, that fix is the (or a) trigger
+6. If pass → 2-3 routes quick session, confirm summary appears
+
+## Phase 2 — Bundle branches (combinations)
+
+After Phase 1, if all individuals pass, test bundles:
+
+| Bundle | Contains | PR | zappsim peak | main.js | Result |
+|--------|----------|----|--------------|---------|--------|
+| `feat/adr-003-completion` | #90 + #92 + #93 + ext19 (4 safest, no cooldown/dwell) | [#110](https://github.com/wylandplex/suuntoplus-climb-logger/pull/110) | 98.3% | 17127 B | [ ] |
+| `feat/adr-003-completion-plus-cooldown` | Above + #89 cooldown | [#111](https://github.com/wylandplex/suuntoplus-climb-logger/pull/111) | 98.5% | 17127 B | [ ] |
+| `feat/v2.99-all-safe-fixes` | All 6 fixes (incl. CLIMB dwell) | [#112](https://github.com/wylandplex/suuntoplus-climb-logger/pull/112) | 98.9% | **17320 B** | [ ] |
+
+If bundle A passes but B/C fail → cooldown or CLIMB dwell is the trigger.
+If all bundles fail → it's a COMBINATION effect, need deeper investigation.
+
+## Phase 3 — Decision
+
+Based on Phase 1+2 results:
+- If individual A crashes → that fix is the bug, file new issue, exclude from v2.99
+- If only bundles crash → combination effect, pick safest bundle as v2.99 candidate
+- If everything passes → finalize v2.99 = bundle C, ship as v2.99 release
+
+## Test mode recommendations
+
+- **Multi-app**: same setup as past tests (climbl01 + zzwethen + zzaeroen + watchface)
+- **Routes per smoke test**: 2-3 minimum, 10+ if app stays stable
+- **Watch on wrist**: yes (ALS sensor active per past crash analysis)
+- **Charger**: NOT plugged in (avoid PMIC noise)
+
+## Known issues not addressed in v2.99
+
+- [#94](https://github.com/wylandplex/suuntoplus-climb-logger/issues/94) Project mode UX + persistence — milestoned v3.0
+- "Cycling activity log shows climb-logger but no summary card" — likely fixed by #109 if root cause confirmed
+
+## zappsim methodology note
+
+`npm run test:rapid-stress` simulates 100 routes back-to-back. This is a worst-case proxy for heap accumulation. Real-world watch may tolerate different limits — these are SIMULATED predictions, not ground truth. Watch-test always wins.

--- a/TEST_PLAN_2026-05-20.md
+++ b/TEST_PLAN_2026-05-20.md
@@ -45,39 +45,31 @@ After Phase 1, if all individuals pass, test bundles:
 If bundle A passes but B/C fail → cooldown or CLIMB dwell is the trigger.
 If all bundles fail → it's a COMBINATION effect, need deeper investigation.
 
-## Phase 3 — ADR-002 Variant A experimental branches
+## Phase 3 — ADR-002 Variant A (uiViewSet) — ❌ KILLED 2026-05-20
 
-Built overnight per user request "ADR-002 A do whole dev cycle". Replaces applyVis() setStyle visibility-toggle with Suunto `<uiViewSet>` framework element.
+Built + watch-tested + **REJECTED**. uiViewSet caused catastrophic path-param overflow + firmware ASSERT + BOOTLOOP within ~40s, reproducible across watch restart.
 
-| Branch | What | PR | zappsim peak |
-|--------|------|----|--------------|
-| `experimental/adr-002-variant-a-uiviewset` | Variant A standalone | [#115](https://github.com/wylandplex/suuntoplus-climb-logger/pull/115) | **97.5%** ← best heap |
-| `experimental/adr-002-A-plus-safe-fixes` | Variant A + #92 + #93 + ext19 | [#116](https://github.com/wylandplex/suuntoplus-climb-logger/pull/116) | **97.7%** ← 2nd best |
+Root cause: uiViewSet holds ALL 6 children's eval-binding path-params SIMULTANEOUSLY resolved → firmware `res:2129` overflow. ADR-002 Variant A's premise was inverted. See [ADR-002 REJECTED](docs/adr/ADR-002-binding-architecture.md) + [PR #114](https://github.com/wylandplex/suuntoplus-climb-logger/pull/114).
 
-⚠ Known caveat: first-install flash. cm.html marks sc0 as `class="selected"` default view. main.js defaults to state=4 (setup) on fresh install only. Existing users (state=0) no flash. Documented in PR #115.
+Experimental branches deleted. PRs #115/#116 closed WONTFIX. zappsim blind spot logged as [#117](https://github.com/wylandplex/suuntoplus-climb-logger/issues/117).
 
-⚠ Per Suunto docs: uiViewSet does NOT lazy-subscribe bindings (verified via cc-f-activity.html example). Variant A is a code-organization + slight heap win, not a WB-path-budget win.
-
-Test order if Phase 1+2 reveal no crash trigger:
-1. Flash `experimental/adr-002-variant-a-uiviewset` (standalone)
-2. If passes: flash `experimental/adr-002-A-plus-safe-fixes` (integrated)
-3. If both pass: strong v3.x architecture candidate
+**No Phase 3 testing — uiViewSet is a dead end. Skip directly to Phase 4.**
 
 ## Phase 4 — Decision
 
-Based on Phase 1+2+3 results:
+Based on Phase 1+2 results:
 - If individual fix crashes → that fix is the bug, exclude from v2.99
 - If only bundles crash → combination effect, pick safest bundle
-- If Variant A bundle wins → migrate v3.x to uiViewSet architecture
 - If everything passes → finalize v2.99 = lowest-heap working bundle, ship release
+- uiViewSet architecture is OFF the table (Phase 3 killed)
 
 ## Full heap comparison (zappsim rapid-stress 100 routes)
 
 | Branch | Peak | main.js |
 |--------|------|---------|
 | master (v2.98) | 98.0% | 17127 B |
-| **experimental/adr-002-variant-a-uiviewset** | **97.5%** | 17127 B |
-| **experimental/adr-002-A-plus-safe-fixes** | **97.7%** | 17127 B |
+| ~~experimental/adr-002-variant-a-uiviewset~~ | ~~97.5%~~ | ❌ KILLED — watch crash |
+| ~~experimental/adr-002-A-plus-safe-fixes~~ | ~~97.7%~~ | ❌ KILLED — watch crash |
 | fix/93-snapshot-reorder | 98.0% | 17127 B |
 | fix/ext19-no-ls-writes | 98.0% | 17127 B |
 | fix/90-applyvis-eval-binding | 98.0% | 17127 B |

--- a/TEST_PLAN_2026-05-20.md
+++ b/TEST_PLAN_2026-05-20.md
@@ -45,12 +45,48 @@ After Phase 1, if all individuals pass, test bundles:
 If bundle A passes but B/C fail → cooldown or CLIMB dwell is the trigger.
 If all bundles fail → it's a COMBINATION effect, need deeper investigation.
 
-## Phase 3 — Decision
+## Phase 3 — ADR-002 Variant A experimental branches
 
-Based on Phase 1+2 results:
-- If individual A crashes → that fix is the bug, file new issue, exclude from v2.99
-- If only bundles crash → combination effect, pick safest bundle as v2.99 candidate
-- If everything passes → finalize v2.99 = bundle C, ship as v2.99 release
+Built overnight per user request "ADR-002 A do whole dev cycle". Replaces applyVis() setStyle visibility-toggle with Suunto `<uiViewSet>` framework element.
+
+| Branch | What | PR | zappsim peak |
+|--------|------|----|--------------|
+| `experimental/adr-002-variant-a-uiviewset` | Variant A standalone | [#115](https://github.com/wylandplex/suuntoplus-climb-logger/pull/115) | **97.5%** ← best heap |
+| `experimental/adr-002-A-plus-safe-fixes` | Variant A + #92 + #93 + ext19 | [#116](https://github.com/wylandplex/suuntoplus-climb-logger/pull/116) | **97.7%** ← 2nd best |
+
+⚠ Known caveat: first-install flash. cm.html marks sc0 as `class="selected"` default view. main.js defaults to state=4 (setup) on fresh install only. Existing users (state=0) no flash. Documented in PR #115.
+
+⚠ Per Suunto docs: uiViewSet does NOT lazy-subscribe bindings (verified via cc-f-activity.html example). Variant A is a code-organization + slight heap win, not a WB-path-budget win.
+
+Test order if Phase 1+2 reveal no crash trigger:
+1. Flash `experimental/adr-002-variant-a-uiviewset` (standalone)
+2. If passes: flash `experimental/adr-002-A-plus-safe-fixes` (integrated)
+3. If both pass: strong v3.x architecture candidate
+
+## Phase 4 — Decision
+
+Based on Phase 1+2+3 results:
+- If individual fix crashes → that fix is the bug, exclude from v2.99
+- If only bundles crash → combination effect, pick safest bundle
+- If Variant A bundle wins → migrate v3.x to uiViewSet architecture
+- If everything passes → finalize v2.99 = lowest-heap working bundle, ship release
+
+## Full heap comparison (zappsim rapid-stress 100 routes)
+
+| Branch | Peak | main.js |
+|--------|------|---------|
+| master (v2.98) | 98.0% | 17127 B |
+| **experimental/adr-002-variant-a-uiviewset** | **97.5%** | 17127 B |
+| **experimental/adr-002-A-plus-safe-fixes** | **97.7%** | 17127 B |
+| fix/93-snapshot-reorder | 98.0% | 17127 B |
+| fix/ext19-no-ls-writes | 98.0% | 17127 B |
+| fix/90-applyvis-eval-binding | 98.0% | 17127 B |
+| fix/89-cooldown | 98.2% | 17127 B |
+| fix/92-lazy-cache | 98.3% | 17127 B |
+| feat/adr-003-completion | 98.3% | 17127 B |
+| fix/89-climb-dwell | 98.5% | **17320 B** |
+| feat/adr-003-completion-plus-cooldown | 98.5% | 17127 B |
+| feat/v2.99-all-safe-fixes | 98.9% | **17320 B** |
 
 ## Test mode recommendations
 


### PR DESCRIPTION
## Summary

Adds `TEST_PLAN_2026-05-20.md` with the complete bisect test schedule for tomorrow's watch-test session.

Documents:
- All 6 isolated branch PRs (#97, #105, #106, #107, #108, #109) with expected zappsim peak heap
- 3 bundle branch PRs (#110, #111, #112) for progressive combination testing
- Phase 1 (individual) → Phase 2 (bundles) → Phase 3 (decide v2.99 candidate)
- Multi-app test environment recommendations

## Why

User watch-test 2026-05-19 22:38 crashed with release/v2.99 HEAD `96712a5` (6 fixes bundled). zappsim couldn't reproduce — all individual fixes ≤ 0.5% heap delta. Need empirical isolation to identify which fix(es) trigger the crash in combination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)