### PR TITLE
docs(adr-002): REJECTED — Variant A uiViewSet empirically killed on watch

### DIFF
--- a/docs/adr/ADR-002-binding-architecture.md
+++ b/docs/adr/ADR-002-binding-architecture.md
@@ -1,9 +1,23 @@
 # ADR-002: Binding Architecture — From Monolithic Template to State-Cluster Split
 
-**Status:** PENDING — awaiting Phase 0 empirical validation
+**Status:** SUPERSEDED by [ADR-003](ADR-003-v2.98-output-reduction.md) for variants A/B; remaining as historical record
 **Date:** 2026-05-18
 **Deciders:** App owner (skyfi)
 **Supersedes:** Implicit "single-template-with-visibility-toggle" approach from v3.0
+
+## Update 2026-05-19 22:55 — `<uiViewSet>` capability check (was Variant A blocker)
+
+Suunto framework docs (`reference.html` h4 `uiviewset`) confirm: `<uiViewSet>` is a VISIBILITY-SWITCHING element, not a binding-lifecycle element.
+
+- Child `<div>` elements coexist in the DOM
+- Class `selected` indicates default child
+- Switching via `navigate('id', N)`, `next()`, `previous()`, `first()`, `last()`
+- Events: `onWakeUp`, `onIdle`, `onSelectionChanged`
+- **Bindings inside non-selected children are NOT unsubscribed** — docs make no mention of binding lifecycle, only visibility
+
+This invalidates ADR-002 Variant A's premise (bindings only register when activated). Per ADR-003's empirical finding, the 46 `<eval input>` bindings already coalesce to 21 unique WB paths via framework dedup, so binding-side restructuring (Variants A and B) cannot meaningfully reduce WB pressure.
+
+**Variants A and B remain ARCHITECTURALLY SOUND for code organization** (cleaner state-cluster separation) but offer **no measurable runtime/heap/path-budget benefit** over the v2.98 single-template approach with output-side optimizations (ADR-003).
 
 ## Context
 

--- a/docs/adr/ADR-002-binding-architecture.md
+++ b/docs/adr/ADR-002-binding-architecture.md
@@ -1,23 +1,64 @@
 # ADR-002: Binding Architecture — From Monolithic Template to State-Cluster Split
 
-**Status:** SUPERSEDED by [ADR-003](ADR-003-v2.98-output-reduction.md) for variants A/B; remaining as historical record
+**Status:** REJECTED — Variant A empirically killed on watch; Variant B not pursued. ADR-003 (output reduction) is the adopted architecture.
 **Date:** 2026-05-18
 **Deciders:** App owner (skyfi)
 **Supersedes:** Implicit "single-template-with-visibility-toggle" approach from v3.0
 
-## Update 2026-05-19 22:55 — `<uiViewSet>` capability check (was Variant A blocker)
+## Update 2026-05-20 — Variant A (`<uiViewSet>`) EMPIRICALLY KILLED on watch
 
-Suunto framework docs (`reference.html` h4 `uiviewset`) confirm: `<uiViewSet>` is a VISIBILITY-SWITCHING element, not a binding-lifecycle element.
+Variant A was fully implemented and watch-tested (branch `experimental/adr-002-variant-a-uiviewset`, since deleted). **Result: catastrophic failure, reproducible across watch restarts.**
 
-- Child `<div>` elements coexist in the DOM
-- Class `selected` indicates default child
-- Switching via `navigate('id', N)`, `next()`, `previous()`, `first()`, `last()`
-- Events: `onWakeUp`, `onIdle`, `onSelectionChanged`
-- **Bindings inside non-selected children are NOT unsubscribed** — docs make no mention of binding lifecycle, only visibility
+### Watch-test 2026-05-20 (log: `logging/log.log` 08:02–09:14)
 
-This invalidates ADR-002 Variant A's premise (bindings only register when activated). Per ADR-003's empirical finding, the 46 `<eval input>` bindings already coalesce to 21 unique WB paths via framework dedup, so binding-side restructuring (Variants A and B) cannot meaningfully reduce WB pressure.
+```
+08:02:50  climbl01 (uiViewSet build) enabled
+08:03:33  ERR WBMAIN "Too many sim. path-param calls cli:32921 res:2129" ×19
+          JsTotMem 129876→131676 (97.6% → 98.9%)
+08:03:43  relMemCb → "Zapp:RelMem->None avail"  (heap fully exhausted)
+08:04:30  path-param overflow ×18 again
+09:14:31  ERR DUKTAPE JSalloc:2445 fail
+09:14:34  ERR FAULT *ASSERT* file.cpp:149 task:ui → EVT BOOTLOOP
+```
 
-**Variants A and B remain ARCHITECTURALLY SOUND for code organization** (cleaner state-cluster separation) but offer **no measurable runtime/heap/path-budget benefit** over the v2.98 single-template approach with output-side optimizations (ADR-003).
+Crash within ~40 s of app launch. Reproduced identically after a full watch restart.
+
+### Root cause — Variant A's premise was INVERTED
+
+ADR-002 assumed `<uiViewSet>` registers child bindings lazily (only the
+active view) → fewer simultaneous paths. **The opposite is true.**
+
+`<uiViewSet>` holds **ALL** children's `<eval>` path-params SIMULTANEOUSLY
+resolved — for the transition system, even with `transition.duration="0"`.
+The path-param dump at 08:03:33 shows ~19+ paths from `lcli:8083` (UI
+client) all active at once. 6 sections × ~8 eval bindings each → the
+firmware path-param resolver (`res:2129`) overflows immediately.
+
+Plain `visibility:HIDDEN` divs do NOT all count against the simultaneous
+path-param budget — the framework handles hidden-div bindings differently.
+`<uiViewSet>` forces every child's bindings into the resolver at once.
+
+**Therefore the v2.98 `setStyle` visibility-toggle pattern is not just
+"acceptable" — it is the ONLY structure that respects the path-param
+budget. uiViewSet is strictly worse.**
+
+### zappsim blind spot
+
+zappsim gave a false-green: heap estimator 97.7% (looked fine), pathBudget
+detector WB-load 35 (looked fine). Neither models the *simultaneous*
+path-param resolver that `<uiViewSet>` inflates. Logged as a zappsim
+enhancement (uiViewSet path-param amplification detector).
+
+### Verdict
+
+- **Variant A: REJECTED** — empirically catastrophic, do not revisit
+- **Variant B (2-cluster template split): NOT PURSUED** — would also keep
+  all cluster bindings simultaneously active within a cluster; same risk
+  class, and ADR-003 output reduction already solved the multi-app freeze
+- **Adopted architecture: ADR-003** (output reduction + caching, v2.98)
+
+The single-template + `setStyle` visibility approach stays. ADR-002 is
+closed as REJECTED.
 
 ## Context
 

--- a/docs/adr/ADR-003-v2.98-output-reduction.md
+++ b/docs/adr/ADR-003-v2.98-output-reduction.md
@@ -1,0 +1,158 @@
+# ADR-003: v2.98 Output Reduction + Caching — Multi-App Stability Without Refactor
+
+**Status:** ADOPTED (2026-05-19), watch-verified
+**Date:** 2026-05-19
+**Deciders:** App owner (skyfi)
+**Supersedes:** [ADR-002](ADR-002-binding-architecture.md) variants A/B (template split / `<uiViewSet>`)
+
+## Context
+
+After [ADR-002](ADR-002-binding-architecture.md) was drafted as a template-split proposal, a multi-agent fresh forensic pass on 2026-05-19 (forensics + framework research + planner agents in parallel) overturned the underlying model.
+
+### What ADR-002 assumed
+- "46 eval-bindings persistently subscribed → exceeds 80-path WB limit → multi-app freeze"
+- "Visibility-toggle doesn't unsubscribe; need uiViewSet OR template split"
+
+### What the logs actually showed (session 2026-05-19 15:30-15:35, solo + multi-app)
+
+**Climb-Logger UI holds stable 23 LIDs (`lcli:8083`) across all states.** The 46 `<eval input>` tags coalesce to 21 unique WB paths (Suunto framework dedupes by path). Adding 2 more LIDs for `{zapp_index}` resolution = 23. **Verified to NOT vary with state.**
+
+**Real saturation driver:** `lcli:8099` (= `cli:32921`, a WB-internal Activity-Manager) subscribes to ALL of Climb-Logger's manifest outputs. Per output = 1 path in 8099's set. With 16 outputs, 8099 holds 28+ paths just for Climb-Logger. Multi-app adds ZoneSense + Calistenics → ~80 paths total, saturating the WB resolver.
+
+**Real heap killer:** per-route work, NOT binding count:
+- `loadExt(10)` re-parsed ext10.js (~500 B parse tree) on EVERY route commit. 20 routes = 10 KB fragmentation.
+- `localStorage.setObject("climbProjStats", ps)` inside ext10.js fired on EVERY route. Growing object × N writes = ~22 KB of temp buffer allocations.
+
+**Crash classes observed (master v3.0 baseline):**
+1. WBMAIN `res:2129` Too many sim. path-param calls — multi-app saturates the 80-path budget
+2. WBAPI `507` code — silent rejection of output writes when saturated
+3. Duktape `JsTotMem` 96-98% — heap exhaustion accumulating over routes
+4. Duktape `*ASSERT* duktapeScriptEngine.cpp:47` — fatal:uncaught error during eval-binding compile under heap pressure (`(x => x >= 0 ? x + 'T')(0.000)` was a victim, not a cause)
+5. ARM Cortex `HardFault (task:ui)` with `CFSR=0x01000000 IBUSERR` — corrupted return address during ext11.js parse under heap pressure
+6. `Zapp climbl01:Disable` (firmware initiated) → black screen + stats lost when state transitions don't reach `onExerciseEnd`
+
+## Decision
+
+Solve at the **per-route work** level and **manifest output count** level, NOT at the template/binding-lifecycle level:
+
+### T5 — Remove `actT/actS/actB` outputs from manifest, push via `setText`
+
+Manifest `out[]`: 16 → 13. cm.html: 3 arrow-function-formatter eval-bindings → 3 `<span id>` placeholders. main.js: new `pushActStats()` helper called from event handlers only.
+
+- Eliminates 3 paths from `lcli:8099`'s read set
+- Eliminates 3 arrow-fn formatter compiles per output change (heap thrashing under saturation)
+- Per memory rule `feedback_event_driven_pushx`: setText NEVER from evaluate/setOutputs
+
+### T6 — Remove `routeNum, totalSends, editSend` outputs too
+
+Manifest 13 → 10. 3 more eval-bindings → `<span id>`. New `pushBrk()` (sc2 break screen) and `pushEdit()` (sc5 edit screen) helpers, also event-driven only.
+
+- Eliminates 6 unique paths from `lcli:8099`'s read set total (T5+T6)
+- cm.html unique-eval-paths drops from 21 → 15
+
+### T7 — Cache `loadExt` results at onLoad
+
+```js
+var f10, f11, f17;
+// In onLoad:
+f10 = loadExt(10);
+f11 = loadExt(11);
+f17 = loadExt(17);
+// Hot paths use f10(...), f11(...), f17(...) directly
+```
+
+`loadExt(N)(...)` re-parses ext-file on every call. Per memory rule `feedback_cache_loadext` (created post-v2.98 as a learning record): cache parsed-function references at onLoad, reuse without reparse.
+
+**Empirical impact:** before v2.98, 20× ext10.js parse per session = ~10 KB heap fragmentation. After v2.98, 1× ext10 parse total per app load.
+
+### T8 — Defer projStats LS write
+
+Remove `localStorage.setObject("climbProjStats", ps)` from ext10.js. Add `projStatsDirty` flag in main.js, set at mutation sites (commitDirty, evEdit toggle, evEdit delete). Flush in two places:
+- `goState(0)` entry (user back to ready screen — natural batch point)
+- `onExerciseEnd` (safety net)
+
+**Empirical impact:** before v2.98, 50× LS writes per 50-route session = ~22 KB temp buffer allocations + 50 flash I/O blocks. After v2.98, 1-N batched writes (N = state-back-to-ready cycles per session).
+
+## What was NOT changed
+
+- `cm.html` single-template architecture — kept
+- `goState()` state machine — kept
+- `applyVis()` visibility-toggle pattern — kept (though `$.subscribe` → `<eval>` workaround applied separately, see [#90](https://github.com/wylandplex/suuntoplus-climb-logger/issues/90) resolution)
+- `<uiViewSet>` framework — NOT investigated (avoided)
+- Template split — NOT done
+
+## Options Considered
+
+### Option A (RECOMMENDED, ADOPTED) — Output reduction + caching
+What this ADR documents above. T5+T6+T7+T8 chain.
+
+| Dimension | Assessment |
+|-----------|------------|
+| Complexity | Medium (4 incremental commits) |
+| Cost | None (smaller manifest, smaller hot paths) |
+| Reversibility | High — each T-step independent |
+| Empirical risk | Low — each step watch-tested in isolation |
+| Path-budget impact | -6 LIDs from lcli:8099 read set |
+| Heap impact | -25 KB per 50-route session |
+
+**Pros:**
+- Incrementally validated (T5, T6, T7, T8 each tested before stacking)
+- No framework primitives discovery needed
+- main.js footprint grew only +1122 B (still under parser budget max)
+
+**Cons:**
+- First-paint after onLoad: setText-bound spans are empty until first `goState()` (cosmetic — not crash)
+- ext14.js (saveAsProject) still uncached — see [#91](https://github.com/wylandplex/suuntoplus-climb-logger/issues/91)
+- Some outputs still publish-per-tick (routeHeight) — necessary for live altitude display, accepted
+
+### Option B (REJECTED) — Template split (ADR-002 Variant B)
+Split cm.html into `active.html` + `manage.html`. Decision deferred 2026-05-18, never executed; fresh analysis on 2026-05-19 showed the premise (binding count = saturation cause) was wrong.
+
+### Option C (REJECTED, attempted once as v3.0.3, reverted) — Variante D Lazy-Output Push
+Remove 9 outputs at once, push all via setText helpers, including from per-tick paths. Failed because helpers were called from 1Hz `setOutputs()` — heap thrashing within Duktape GC capacity. Memory rule `feedback_event_driven_pushx` codified the lesson: setText NEVER per-tick.
+
+### Option D (REJECTED) — VBUS storm resilience
+ADR-003 first-draft proposed making Climb-Logger "resilient to WB storms it cannot prevent" (VBUS charger events triggering WB resubscribe). Discarded because actual fix (T5-T8) solved the underlying heap+path-budget pressure, making the resilience layer unnecessary.
+
+## Consequences
+
+**What became easier:**
+- Multi-app coexistence — Climb-Logger uses ~10 paths from system consumers vs 16 before
+- Per-route work is now constant-time (no growing structures touched per route)
+- Future feature additions: each `output` carries a cost (one path in lcli:8099 read set) — explicit accounting
+
+**What became harder:**
+- First-paint requires `goState()` to fire before user sees correct values — small UX gap
+- Outputs are no longer the only way to drive UI updates — must remember setText pattern for non-publishable values
+- Architectural change requires updating both manifest, cm.html, and main.js together (3-file coordinated change)
+
+**What we'll need to revisit:**
+- `applyVis` subscribe pattern: replaced with hidden-`<eval>` workaround inline ([#90](https://github.com/wylandplex/suuntoplus-climb-logger/issues/90)) — main.js subscribe would be cleaner but works
+- ext14.js cache ([#91](https://github.com/wylandplex/suuntoplus-climb-logger/issues/91)) — saveAsProject still reparses
+- Long-session validation ([#95](https://github.com/wylandplex/suuntoplus-climb-logger/issues/95)) — fast-click 80 routes ≠ real climbing 20-50 routes × 10 min
+- Lap reliability ([#93](https://github.com/wylandplex/suuntoplus-climb-logger/issues/93)) — independent of v2.98 fix
+- Project persistence ([#94](https://github.com/wylandplex/suuntoplus-climb-logger/issues/94)) — user-reported, needs investigation
+
+## Action Items (post-merge to main)
+
+- [x] Merge T5+T6+T7+T8 chain to master, tag v2.98
+- [x] Close issues #86 and #87 with v2.98 reference
+- [x] Update memory `project_v3_status.md` and create `feedback_cache_loadext.md`
+- [x] Backlog: #89, #90, #91, #92, #93, #94, #95 created for remaining work
+- [ ] Long-session real-climbing validation ([#95](https://github.com/wylandplex/suuntoplus-climb-logger/issues/95))
+
+## Architectural Lessons Learned
+
+1. **Heap pressure on Vertical 2 is accumulation, not spikes.** Per-tick work that "looks small" multiplies over time. Caching parsed functions, deferring LS writes, capping mutable arrays — all matter.
+
+2. **Manifest outputs cost more than you think.** Each declared output is one path that `lcli:8099` (Activity-Manager) subscribes to. With multi-app, this is the dominant WB-path-budget pressure, not the in-template eval-binding count.
+
+3. **`evalFile` re-parse is the silent killer.** Suunto framework does NOT cache parsed function references. Cache them yourself in `onLoad`.
+
+4. **LS writes have hidden allocation cost.** Each `localStorage.setObject()` serializes through a temp buffer + blocks the UI task on flash I/O. Defer when possible.
+
+5. **VBUS-events DO trigger WB resubscribe storms.** Climb-Logger isn't the cause but is collateral damage. Reducing our footprint helps survive them, but the storms themselves are environmental and unavoidable. ([Issue #92](https://github.com/wylandplex/suuntoplus-climb-logger/issues/92) bystander effect)
+
+6. **`lcli:8099` reads ALL outputs back, not just `log:true`.** Reducing the manifest directly reduces this consumer's read scope. This was the highest-leverage insight from forensic analysis.
+
+7. **Multi-agent fresh analysis broke the circle-thinking loop.** When 3 iterations of architecture-redesign all failed, running 3 independent agents (forensics, framework research, planning) without any prior solution context produced the correct empirical model. Memory `feedback_empirical_before_architecture` records this as a reusable pattern.


### PR DESCRIPTION
## Summary

ADR-002 Variant A (uiViewSet refactor) was fully built, watch-tested, and **empirically killed**. This PR updates ADR-002 status PENDING → REJECTED with the crash forensics, and commits the previously-untracked ADR-003 file.

## Watch-test result (2026-05-20, reproducible across restart)

```
08:02:50  uiViewSet build enabled
08:03:33  "Too many sim. path-param calls cli:32921 res:2129" ×19, JsTotMem 98.9%
08:03:43  relMemCb → "RelMem->None avail" (heap exhausted)
09:14:31  DUKTAPE JSalloc:2445 fail
09:14:34  ERR FAULT *ASSERT* file.cpp:149 task:ui → BOOTLOOP
```

## Root cause

ADR-002 Variant A's premise was **inverted**. uiViewSet does NOT lazy-register bindings per active view — it holds ALL 6 children's ~46 eval path-params SIMULTANEOUSLY resolved (transition system, even at `transition.duration=0`). Plain `visibility:HIDDEN` divs don't all hit the simultaneous-path-param resolver budget; uiViewSet forces them to → guaranteed `res:2129` overflow within ~40s.

The v2.98 `setStyle` visibility-toggle pattern is the ONLY structure that respects the path-param budget.

## Changes

- `ADR-002-binding-architecture.md` — status PENDING → REJECTED, full crash forensics added
- `ADR-003-v2.98-output-reduction.md` — committed (was untracked, referenced by README + ADR-002)

## Follow-up

zappsim blind spot: heap estimator (97.7%) and pathBudget (WB-load 35) both gave false-green. Neither models the simultaneous-path-param resolver. Logged as separate zappsim enhancement issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)