### PR TITLE
feat(adr-002-A): refactor cm.html to uiViewSet — experimental

### DIFF
--- a/cm.html
+++ b/cm.html
@@ -7,6 +7,7 @@
           function sN(x){return SN[x]||'?'}
           var lapState=4,lock=0;
           function applyView(x){
+            if(x===lapState)return;
             lapState=x;lock=0;
             if(x===0||x===1||x===2||x===4||x===5||x===6) navigate('vs','sc'+x);
           }

--- a/cm.html
+++ b/cm.html
@@ -6,16 +6,11 @@
           function dG(x){return x>=0?(x%100>=50?'OFF':(G[Math.floor(x/100)]||'').split(',')[x%100]||'?'):'--'}
           function sN(x){return SN[x]||'?'}
           var lapState=4,lock=0;
-          function applyVis(x){
+          function applyView(x){
             lapState=x;lock=0;
-            setStyle('#sc0','visibility',x===0?'VISIBLE':'HIDDEN');
-            setStyle('#sc1','visibility',x===1?'VISIBLE':'HIDDEN');
-            setStyle('#sc2','visibility',x===2?'VISIBLE':'HIDDEN');
-            setStyle('#sc4','visibility',x===4?'VISIBLE':'HIDDEN');
-            setStyle('#sc5','visibility',x===5?'VISIBLE':'HIDDEN');
-            setStyle('#sc6','visibility',x===6?'VISIBLE':'HIDDEN');
+            if(x===0||x===1||x===2||x===4||x===5||x===6) navigate('vs','sc'+x);
           }
-          $.subscribe('/Zapp/{zapp_index}/Output/vState',applyVis);
+          $.subscribe('/Zapp/{zapp_index}/Output/vState',applyView);
           function ev(n){$.put('/Zapp/{zapp_index}/Event',n,null,'int32')}
           function lap(){$.put('/Activity/Trigger',23)}
           function evX(n){if(lock)return;ev(n);lock=1}
@@ -26,10 +21,17 @@
     <!-- Grauer Rombus-Hintergrund für die Bottom-Time-Bar (auf jedem Screen sichtbar) -->
     <div style="position:absolute;top:84%;left:15%;width:70%;height:14%;background:rgba(255,255,255,0.15);clip-path:polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);"></div>
 
+    <!-- ADR-002 Variant A: uiViewSet replaces applyVis() setStyle visibility toggling.
+         Framework-managed view switching via navigate('vs', 'sc<N>'). transition.duration=0
+         for instant switches. NOTE per Suunto docs: bindings inside non-selected children
+         stay subscribed (no lazy subscription benefit) — this is a code-organization win,
+         not a runtime win. -->
+    <uiViewSet id="vs" style="position:absolute;top:0;left:0;width:100%;height:100%" transition.duration="0">
+
     <!-- ============================================================ -->
     <!-- SECTION 0: READY (state=0) — pre-climb grade selection         -->
     <!-- ============================================================ -->
-    <div id="sc0" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:VISIBLE">
+    <div id="sc0" class="selected" style="position:absolute;top:0;left:0;width:100%;height:100%">
 
       <div class="cm-fg" style="width:100%;height:16%">
         <div class="sp-t-s p-hc" style="top:calc(50% - 50%e);">
@@ -86,7 +88,7 @@
     <!-- ============================================================ -->
     <!-- SECTION 1: CLIMB (state=1) — active route timer + HR           -->
     <!-- ============================================================ -->
-    <div id="sc1" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:HIDDEN">
+    <div id="sc1" style="position:absolute;top:0;left:0;width:100%;height:100%">
 
       <div class="cm-fg" style="width:100%;height:16%">
         <div class="sp-t-s" style="top:calc(50% - 50%e); left:calc(50% - 50%e);">
@@ -141,7 +143,7 @@
     <!-- ============================================================ -->
     <!-- SECTION 2: BREAK (state=2) — post-route stats                  -->
     <!-- ============================================================ -->
-    <div id="sc2" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:HIDDEN">
+    <div id="sc2" style="position:absolute;top:0;left:0;width:100%;height:100%">
 
       <div class="cm-fg" style="width:100%;height:16%">
         <div class="sp-t-s p-hc" style="top:calc(50% - 50%e);">
@@ -222,7 +224,7 @@
     <!-- ============================================================ -->
     <!-- SECTION 4: SETUP (state=4) — grade-system wizard               -->
     <!-- ============================================================ -->
-    <div id="sc4" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:HIDDEN">
+    <div id="sc4" style="position:absolute;top:0;left:0;width:100%;height:100%">
 
       <div class="f-ico p-hc" style="top:calc(22% - 50%e);">&#xF102;</div>
 
@@ -257,7 +259,7 @@
     <!-- ============================================================ -->
     <!-- SECTION 5: EDIT (state=5) — modify saved routes               -->
     <!-- ============================================================ -->
-    <div id="sc5" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:HIDDEN">
+    <div id="sc5" style="position:absolute;top:0;left:0;width:100%;height:100%">
 
       <div class="cm-fg" style="width:100%;height:16%">
         <div class="p-hc sp-vertical-center" style="top:calc(50% - 50%e);">
@@ -318,7 +320,7 @@
     <!-- ============================================================ -->
     <!-- SECTION 6: PROJSETUP (state=6) — define 5 project grade slots -->
     <!-- ============================================================ -->
-    <div id="sc6" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:HIDDEN">
+    <div id="sc6" style="position:absolute;top:0;left:0;width:100%;height:100%">
 
       <div class="sp-b-s p-hc" style="top:calc(22% - 50%e);">
         <span>PROJECT </span>
@@ -357,6 +359,8 @@
         <span class="sp-b-s f-num"><eval input="/Activity/Move/-1/Duration/Current" outputFormat="Duration_FourdigitsFixed" default="0:00" /></span>
       </div>
     </div>
+
+    </uiViewSet>
 
     <!-- ============================================================ -->
     <!-- Shared physical pushButtons — universal events, main.js dispatches by state -->


### PR DESCRIPTION
## Summary

ADR-002 Variant A experimental refactor: replaces `applyVis()` setStyle visibility-toggle pattern with Suunto framework `<uiViewSet>` element.

## Changes

- `cm.html` only — main.js untouched
- onLoad: replace 9-line applyVis() with 4-line applyView() that calls `navigate('vs', 'sc<N>')`
- Wrap sc0/sc1/sc2/sc4/sc5/sc6 in `<uiViewSet id=\"vs\" transition.duration=\"0\">`
- sc0 marked `class=\"selected\"` as default view
- Remove `visibility:VISIBLE/HIDDEN` from sc# divs (uiViewSet handles it)
- Add guard against duplicate vState republishes (1Hz from setOutputs)

## What this fixes vs. doesn't fix

✓ **Code organization** — state-cluster separation cleaner, removes manual setStyle loop
✓ **Slight heap win** — fewer string allocations per state transition (per zappsim)
✗ **WB path-budget** — bindings inside non-selected uiViewSet children stay subscribed (verified via Suunto reference docs + cc-f-activity.html example). ADR-002's original premise ("bindings only register when activated") was wrong.
✗ **Multi-app stability** — same WB-path count as current pattern, no benefit there

## zappsim heap (rapid-stress 100 routes)

| Version | Peak |
|---------|------|
| master (v2.98) | 98.0% |
| **this branch** | **97.5%** (-0.5 pts) |

## Code review (independent agent)

- 🔴 **First-install flash** — sc0 marked selected, but main.js defaults to state=4 on fresh install → brief flash of READY before applyView(4) navigates to sc4. For existing users (state=0) no flash. Accepted trade-off, documented.
- 🟡 **Duplicate-publish navigate** — vState republished every 1Hz, applyView fires every tick. Fixed with `if(x===lapState) return` guard.
- 🟢 navigate() syntax, child styles, rombus z-order, pushButton scope, attributes — all correct.

## Test plan

Watch test:
- [ ] First launch (with existing watchSetup) — verify sc0 shows immediately, no flash
- [ ] state transitions across all 6 screens (READY/CLIMB/BREAK/SETUP/EDIT/PROJSETUP) — visibility correct
- [ ] Same crash-test as v2.99 bisect — 50+ routes + saveAsProject + multi-app
- [ ] If passes, consider integrating with safer v2.99 fixes (#92, #93, ext19, #90)

## Status

**EXPERIMENTAL** — not part of v2.99 bisect plan. Standalone evaluation. If watch-test passes and offers clear benefit over master, consider for v3.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)