### PR TITLE
feat(adr-002-A): uiViewSet + safer v2.99 fixes integrated bundle

### DIFF
--- a/cm.html
+++ b/cm.html
@@ -19,7 +19,7 @@
           function ev(n){$.put('/Zapp/{zapp_index}/Event',n,null,'int32')}
           function lap(){$.put('/Activity/Trigger',23)}
           function evX(n){if(lock)return;ev(n);lock=1}
-          function evL(n){if(lock)return;ev(n);if((n===6&&lapState===0)||lapState===1){lap();lock=1}}
+          function evL(n){if(lock)return;var s=lapState;if((n===6&&s===0)||s===1){lap();lock=1}ev(n)}
         ">
   <div id="climblogger">
 

--- a/cm.html
+++ b/cm.html
@@ -3,7 +3,8 @@
         onLoad="
           var G='3a,3a+,3b,3b+,3c,3c+,4a,4a+,4b,4b+,4c,4c+,5a,5a+,5b,5b+,5c,5c+,6a,6a+,6b,6b+,6c,6c+,7a,7a+,7b,7b+,7c,7c+,8a,8a+,8b,8b+,8c,8c+,9a,9a+,9b,9b+,9c|4,4+,5-,5,5+,6-,6,6+,7-,7,7+,8-,8,8+,9-,9,9+,10-,10,10+,11-,11,11+,12-|5.5,5.6,5.7,5.8,5.9,5.10a,5.10b,5.10c,5.10d,5.11a,5.11b,5.11c,5.11d,5.12a,5.12b,5.12c,5.12d,5.13a,5.13b,5.13c,5.13d,5.14a,5.14b,5.14c,5.14d,5.15a,5.15b,5.15c,5.15d|4a,4b,4c,5a,5b,5c,6a,6b,6c,7a,7b|VB,V0,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12|4A,4A+,4B,4B+,4C,4C+,5A,5A+,5B,5B+,5C,5C+,6A,6A+,6B,6B+,6C,6C+,7A,7A+,7B,7B+,7C,7C+,8A,8A+,8B,8B+,8C,8C+|WI2,WI3,WI3+,WI4,WI4+,WI5,WI5+,WI6,WI6+,WI7,WI7+|M1,M2,M3,M4,M5,M6,M7,M8,M9,M10,M11,M12|Set|Lap'.split('|');
           var SN='French Sport,UIAA Sport,YDS Sport,British Trad,V-Scale,Font Boulder,Ice (WI),Mixed (M),Hangboard,Scrambling'.split(',');
-          function dG(x){return x>=0?(x%100>=50?'OFF':(G[Math.floor(x/100)]||'').split(',')[x%100]||'?'):'--'}
+          var Gs=null,Gsi=-1;
+          function dG(x){if(x<0)return'--';if(x%100>=50)return'OFF';var si=Math.floor(x/100);if(si!==Gsi){Gs=(G[si]||'').split(',');Gsi=si}return(Gs||[])[x%100]||'?'}
           function sN(x){return SN[x]||'?'}
           var lapState=4,lock=0;
           function applyVis(x){

--- a/cm.html
+++ b/cm.html
@@ -7,6 +7,7 @@
           function sN(x){return SN[x]||'?'}
           var lapState=4,lock=0;
           function applyView(x){
+            if(x===lapState)return;
             lapState=x;lock=0;
             if(x===0||x===1||x===2||x===4||x===5||x===6) navigate('vs','sc'+x);
           }

--- a/cm.html
+++ b/cm.html
@@ -6,16 +6,11 @@
           function dG(x){return x>=0?(x%100>=50?'OFF':(G[Math.floor(x/100)]||'').split(',')[x%100]||'?'):'--'}
           function sN(x){return SN[x]||'?'}
           var lapState=4,lock=0;
-          function applyVis(x){
+          function applyView(x){
             lapState=x;lock=0;
-            setStyle('#sc0','visibility',x===0?'VISIBLE':'HIDDEN');
-            setStyle('#sc1','visibility',x===1?'VISIBLE':'HIDDEN');
-            setStyle('#sc2','visibility',x===2?'VISIBLE':'HIDDEN');
-            setStyle('#sc4','visibility',x===4?'VISIBLE':'HIDDEN');
-            setStyle('#sc5','visibility',x===5?'VISIBLE':'HIDDEN');
-            setStyle('#sc6','visibility',x===6?'VISIBLE':'HIDDEN');
+            if(x===0||x===1||x===2||x===4||x===5||x===6) navigate('vs','sc'+x);
           }
-          $.subscribe('/Zapp/{zapp_index}/Output/vState',applyVis);
+          $.subscribe('/Zapp/{zapp_index}/Output/vState',applyView);
           function ev(n){$.put('/Zapp/{zapp_index}/Event',n,null,'int32')}
           function lap(){$.put('/Activity/Trigger',23)}
           function evX(n){if(lock)return;ev(n);lock=1}
@@ -26,10 +21,17 @@
     <!-- Grauer Rombus-Hintergrund für die Bottom-Time-Bar (auf jedem Screen sichtbar) -->
     <div style="position:absolute;top:84%;left:15%;width:70%;height:14%;background:rgba(255,255,255,0.15);clip-path:polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);"></div>
 
+    <!-- ADR-002 Variant A: uiViewSet replaces applyVis() setStyle visibility toggling.
+         Framework-managed view switching via navigate('vs', 'sc<N>'). transition.duration=0
+         for instant switches. NOTE per Suunto docs: bindings inside non-selected children
+         stay subscribed (no lazy subscription benefit) — this is a code-organization win,
+         not a runtime win. -->
+    <uiViewSet id="vs" style="position:absolute;top:0;left:0;width:100%;height:100%" transition.duration="0">
+
     <!-- ============================================================ -->
     <!-- SECTION 0: READY (state=0) — pre-climb grade selection         -->
     <!-- ============================================================ -->
-    <div id="sc0" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:VISIBLE">
+    <div id="sc0" class="selected" style="position:absolute;top:0;left:0;width:100%;height:100%">
 
       <div class="cm-fg" style="width:100%;height:16%">
         <div class="sp-t-s p-hc" style="top:calc(50% - 50%e);">
@@ -86,7 +88,7 @@
     <!-- ============================================================ -->
     <!-- SECTION 1: CLIMB (state=1) — active route timer + HR           -->
     <!-- ============================================================ -->
-    <div id="sc1" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:HIDDEN">
+    <div id="sc1" style="position:absolute;top:0;left:0;width:100%;height:100%">
 
       <div class="cm-fg" style="width:100%;height:16%">
         <div class="sp-t-s" style="top:calc(50% - 50%e); left:calc(50% - 50%e);">
@@ -141,7 +143,7 @@
     <!-- ============================================================ -->
     <!-- SECTION 2: BREAK (state=2) — post-route stats                  -->
     <!-- ============================================================ -->
-    <div id="sc2" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:HIDDEN">
+    <div id="sc2" style="position:absolute;top:0;left:0;width:100%;height:100%">
 
       <div class="cm-fg" style="width:100%;height:16%">
         <div class="sp-t-s p-hc" style="top:calc(50% - 50%e);">
@@ -222,7 +224,7 @@
     <!-- ============================================================ -->
     <!-- SECTION 4: SETUP (state=4) — grade-system wizard               -->
     <!-- ============================================================ -->
-    <div id="sc4" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:HIDDEN">
+    <div id="sc4" style="position:absolute;top:0;left:0;width:100%;height:100%">
 
       <div class="f-ico p-hc" style="top:calc(22% - 50%e);">&#xF102;</div>
 
@@ -257,7 +259,7 @@
     <!-- ============================================================ -->
     <!-- SECTION 5: EDIT (state=5) — modify saved routes               -->
     <!-- ============================================================ -->
-    <div id="sc5" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:HIDDEN">
+    <div id="sc5" style="position:absolute;top:0;left:0;width:100%;height:100%">
 
       <div class="cm-fg" style="width:100%;height:16%">
         <div class="p-hc sp-vertical-center" style="top:calc(50% - 50%e);">
@@ -318,7 +320,7 @@
     <!-- ============================================================ -->
     <!-- SECTION 6: PROJSETUP (state=6) — define 5 project grade slots -->
     <!-- ============================================================ -->
-    <div id="sc6" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:HIDDEN">
+    <div id="sc6" style="position:absolute;top:0;left:0;width:100%;height:100%">
 
       <div class="sp-b-s p-hc" style="top:calc(22% - 50%e);">
         <span>PROJECT </span>
@@ -357,6 +359,8 @@
         <span class="sp-b-s f-num"><eval input="/Activity/Move/-1/Duration/Current" outputFormat="Duration_FourdigitsFixed" default="0:00" /></span>
       </div>
     </div>
+
+    </uiViewSet>
 
     <!-- ============================================================ -->
     <!-- Shared physical pushButtons — universal events, main.js dispatches by state -->

--- a/ext19.js
+++ b/ext19.js
@@ -1,6 +1,6 @@
 function(routes,rn,sc){
 var n=routes?routes.length:-1;
-if(!routes||n===0){var ph=[{id:'sr',name:'Sends / Routes',format:'Count_Fourdigits',value:0,postfix:'/ 0'}];localStorage.setObject('lastSummary',ph);return ph}
+if(!routes||n===0)return[{id:'sr',name:'Sends / Routes',format:'Count_Fourdigits',value:0,postfix:'/ 0'}];
 var G='3a,3a+,3b,3b+,3c,3c+,4a,4a+,4b,4b+,4c,4c+,5a,5a+,5b,5b+,5c,5c+,6a,6a+,6b,6b+,6c,6c+,7a,7a+,7b,7b+,7c,7c+,8a,8a+,8b,8b+,8c,8c+,9a,9a+,9b,9b+,9c|4,4+,5-,5,5+,6-,6,6+,7-,7,7+,8-,8,8+,9-,9,9+,10-,10,10+,11-,11,11+,12-|5.5,5.6,5.7,5.8,5.9,5.10a,5.10b,5.10c,5.10d,5.11a,5.11b,5.11c,5.11d,5.12a,5.12b,5.12c,5.12d,5.13a,5.13b,5.13c,5.13d,5.14a,5.14b,5.14c,5.14d,5.15a,5.15b,5.15c,5.15d|4a,4b,4c,5a,5b,5c,6a,6b,6c,7a,7b|VB,V0,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12|4A,4A+,4B,4B+,4C,4C+,5A,5A+,5B,5B+,5C,5C+,6A,6A+,6B,6B+,6C,6C+,7A,7A+,7B,7B+,7C,7C+,8A,8A+,8B,8B+,8C,8C+|WI2,WI3,WI3+,WI4,WI4+,WI5,WI5+,WI6,WI6+,WI7,WI7+|M1,M2,M3,M4,M5,M6,M7,M8,M9,M10,M11,M12|Set|Lap'.split('|');
 function dG(x){var si=Math.floor(x/100);return x>=0&&si>=0&&si<=9?(x%100>=50?'OFF':(G[si]||'').split(',')[x%100]||'?'):'--'}
 var s=0,ht=0,sp=-1,spC=0,hp=-1,dur=0,hrSum=0,hrCnt=0;
@@ -17,6 +17,4 @@ if(hp>=0&&hp!==sp)out.push({id:'t',name:'Hardest Try',format:'Count_Fourdigits',
 if(dur>0)out.push({id:'d',name:'Climb Time',format:'Duration_FourdigitsFixed',value:dur});
 if(hrCnt>0)out.push({id:'a',name:'Avg HR',format:'HeartRate_Fourdigits',value:hrSum/hrCnt});
 if(ht>0)out.push({id:'h',name:'Height',format:'Count_Fourdigits',value:htR,postfix:'m'});
-localStorage.setObject('lastSummary',out);
-localStorage.setObject('_sumTmp',{sp:sp,htR:htR});
 return out}


### PR DESCRIPTION
## Summary

Integrates ADR-002 Variant A (uiViewSet refactor, [PR #115](https://github.com/wylandplex/suuntoplus-climb-logger/pull/115)) with the SAFER v2.99 bugfixes:

- ✓ Variant A uiViewSet refactor (replaces applyVis setStyle)
- ✓ #92 lazy single-system grade cache (PR #105)
- ✓ #93 snapshot lapState + reorder lap()/ev() (PR #107)
- ✓ ext19.js LS-write removal (PR #109)

Excluded (heap-pressure-risk):
- ✗ #89 CLIMB dwell (main.js +193B)
- ✗ #89 300ms cooldown (interacts with Variant A's lap-fire timing — needs separate eval)
- ✗ #90 eval-binding for vState (Variant A keeps \$.subscribe directly — both touch same code)

## zappsim heap (rapid-stress 100 routes)

| Version | Peak | main.js |
|---------|------|---------|
| master (v2.98) | 98.0% | 17127 B |
| Variant A alone (PR #115) | 97.5% | 17127 B |
| ADR-003 completion (PR #110) | 98.3% | 17127 B |
| **this bundle** | **97.7%** | **17127 B** |
| v2.99 all 6 fixes (PR #112) | 98.9% | 17320 B |

This is the **lowest-heap multi-fix combination** in v2.99 candidates. Best of both: Variant A's framework-managed visibility + ADR-003 spirit fixes.

## What's NOT addressed

- Fast-click sub-1s routes (#89) — needs cooldown or dwell to be solved. Skipped here for heap safety.
- Multi-app stability — Variant A doesn't help per Suunto docs (bindings stay subscribed). Need ADR-003-style output reduction.

## Test plan

Watch test as bundle:
- [ ] First-launch flash (sc0 selected, main.js may start at state=4) — verify acceptable
- [ ] State transitions across all 6 screens
- [ ] 50+ routes + saveAsProject + multi-app — crash test
- [ ] Summary card appears at activity end (ext19 fix)
- [ ] UP/DOWN cycling snappy (lazy G cache)
- [ ] No lap drops in fast click (snapshot+reorder)

## Status

**EXPERIMENTAL** — alternative to the simple ADR-003 completion bundle (PR #110). If both pass watch-test, this one offers slight heap improvement via uiViewSet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)