### PR TITLE
feat: lighter EDIT screen (edit.html) + external-lap phase advance

### DIFF
--- a/edit.html
+++ b/edit.html
@@ -1,0 +1,91 @@
+<uiView onFlickUp="ev(7)"
+        onFlickDown="ev(8)"
+        onLoad="
+          var G='3a,3a+,3b,3b+,3c,3c+,4a,4a+,4b,4b+,4c,4c+,5a,5a+,5b,5b+,5c,5c+,6a,6a+,6b,6b+,6c,6c+,7a,7a+,7b,7b+,7c,7c+,8a,8a+,8b,8b+,8c,8c+,9a,9a+,9b,9b+,9c|4,4+,5-,5,5+,6-,6,6+,7-,7,7+,8-,8,8+,9-,9,9+,10-,10,10+,11-,11,11+,12-|5.5,5.6,5.7,5.8,5.9,5.10a,5.10b,5.10c,5.10d,5.11a,5.11b,5.11c,5.11d,5.12a,5.12b,5.12c,5.12d,5.13a,5.13b,5.13c,5.13d,5.14a,5.14b,5.14c,5.14d,5.15a,5.15b,5.15c,5.15d|4a,4b,4c,5a,5b,5c,6a,6b,6c,7a,7b|VB,V0,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12|4A,4A+,4B,4B+,4C,4C+,5A,5A+,5B,5B+,5C,5C+,6A,6A+,6B,6B+,6C,6C+,7A,7A+,7B,7B+,7C,7C+,8A,8A+,8B,8B+,8C,8C+|WI2,WI3,WI3+,WI4,WI4+,WI5,WI5+,WI6,WI6+,WI7,WI7+|M1,M2,M3,M4,M5,M6,M7,M8,M9,M10,M11,M12|Set|Lap'.split('|');
+          var Gs=null,Gsi=-1;
+          function dG(x){if(x<0)return'--';if(x%100>=50)return'OFF';var si=Math.floor(x/100);if(si!==Gsi){Gs=(G[si]||'').split(',');Gsi=si}return(Gs||[])[x%100]||'?'}
+          var lock=0;
+          function ev(n){$.put('/Zapp/{zapp_index}/Event',n,null,'int32')}
+          function ulk(){lock=0}
+          function evX(n){if(lock)return;ev(n);lock=1;setTimeout(ulk,300)}
+          function evL(n){if(lock)return;ev(n);lock=1;setTimeout(ulk,300)}
+        ">
+  <div id="climblogger">
+
+    <!-- Grauer Rombus-Hintergrund für die Bottom-Time-Bar -->
+    <div style="position:absolute;top:84%;left:15%;width:70%;height:14%;background:rgba(255,255,255,0.15);clip-path:polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);"></div>
+
+    <!-- Dedicated EDIT screen (state 5) — single always-visible section; no applyVis/section-switching. -->
+    <div id="sc5" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:VISIBLE">
+
+      <div class="cm-fg" style="width:100%;height:16%">
+        <div class="p-hc sp-vertical-center" style="top:calc(50% - 50%e);">
+          <span class="sp-t-s" style="padding-right:4px">EDIT</span>
+          <span id="ed-routeNum" class="sp-t-s f-num">0</span>
+          <span class="sp-t-s" style="padding:0 2px">/</span>
+          <span id="ed-total" class="sp-t-s f-num">0</span>
+        </div>
+      </div>
+
+      <div onTap="ev(1)" style="top:17%;left:0;width:70%;height:22%;position:absolute;"></div>
+      <div id="ed-arrUp" class="f-ico p-hc" style="top:calc(36% - 50%e);">&#xF266;</div>
+
+      <div class="sp-t-l" style="top:calc(48% - 50%e); left:calc(50% - 50%e);">
+        <eval input="/Zapp/{zapp_index}/Output/lastGrade" outputFormat="script x => dG(x)" default="--" />
+      </div>
+
+      <div onTap="ev(2)" style="top:57%;left:0;width:70%;height:25%;position:absolute;"></div>
+      <div id="ed-arrDn" class="f-ico p-hc" style="top:calc(66% - 50%e);">&#xF267;</div>
+
+      <div class="p-hc sp-vertical-center" style="top:calc(78% - 50%e);">
+        <span id="ed-sendIcon" class="f-ico" style="padding-right:6px">?</span>
+        <span id="ed-sendLabel" class="sp-b-m">FAIL</span>
+      </div>
+
+      <div style="top:18%;left:83%;width:15%;height:12%;position:absolute;">
+        <div style="top:0; left:0; width:100%;height:100%;position:absolute;background:rgba(255,255,255,0.15);border-radius:50px 0 0 50px;">
+          <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE365;</div>
+        </div>
+      </div>
+      <div onTap="evX(5)" style="top:11%;left:70%;width:30%;height:25%;position:absolute;"></div>
+
+      <div style="top:44%;left:90%;width:10%;height:12%;position:absolute;">
+        <div style="top:0; left:0; width:100%;height:100%;position:absolute;background:rgba(255,255,255,0.15);border-radius:50px 0 0 50px;">
+          <div id="ed-pillIcon" class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xF107;</div>
+          <div id="ed-pillDel" class="sp-b-s cm-bgc" style="top:calc(50% - 50%e); left:2px;visibility:HIDDEN">DEL</div>
+        </div>
+      </div>
+      <div onTap="ev(4)" style="top:37%;left:70%;width:30%;height:25%;position:absolute;"></div>
+
+      <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;">
+        <div style="top:0; left:0; width:100%;height:100%;position:absolute;background:rgba(255,255,255,0.15);border-radius:50px 0 0 50px;">
+          <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE373;</div>
+        </div>
+      </div>
+      <div onTap="ev(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
+
+    </div>
+
+    <!-- Shared bottom time-bar -->
+    <div class="p-hc sp-vertical-center" style="top:calc(90% - 50%e);">
+      <span class="sp-b-s f-num"><eval input="/Dev/Time/LocalTime" outputFormat="script x => ('0'+Math.floor((x/3600)%24)).slice(-2)+':'+('0'+Math.floor((x/60)%60)).slice(-2)" default="--:--" /></span>
+      <span class="f-ico" style="padding-left:6px;padding-right:6px">&#xF100;</span>
+      <span class="sp-b-s f-num"><eval input="/Activity/Move/-1/Duration/Current" outputFormat="Duration_FourdigitsFixed" default="0:00" /></span>
+    </div>
+
+    <!-- Physical pushButtons — universal events, main.js dispatches by state -->
+    <:if test="{{ HAS_ON_EVENT }}">
+    <userInput>
+      <pushButton name="up" type="lock" longType="lock"
+        onClick="ev(1)"
+        onLongPressStart="evL(5)" />
+      <pushButton name="next" longType="lock"
+        onLongPressStart="ev(4)" />
+      <pushButton name="down" type="lock" longType="lock"
+        onClick="ev(2)"
+        onLongPressStart="evL(6)" />
+    </userInput>
+    </:if>
+
+  </div>
+</uiView>

--- a/main.js
+++ b/main.js
@@ -205,7 +205,7 @@ var goState = function(s, output) {
   var tChanged = (currentTemplate !== t);
   currentTemplate = t;
   if (tChanged) unload('_cm');
-  if (s === 1) dwell = 1;
+  if (s === 1 || s === 3) dwell = 1;  // s===3 (LIMIT) too: a START at the route cap goes onLap->startClimb->goState(3); the trailing onEvent(6) from the SAME press must be absorbed (dwell) or it immediately goState(0)s and the LIMIT screen only flashes
   if (output) setOutputs(output);  // publishes actT/actS/actB (s=0) and brkSends/brkRoutes (s=2)
   // climbProjStats write removed from goState(0) — was a mid-session LS write that
   // triggered ~0.5s flash-GC freezes on break→ready in project mode. Unconditional
@@ -584,7 +584,7 @@ function onEvent(_input, output, eventId) {
   // finish-time snapshots lastGradeIdx + lastClimbMode, so cycling in BREAK can't re-tag it). frDirty is 0 in
   // every non-BREAK state, so this guard only ever fires in the BREAK commit window.
   if (frDirty && (eventId === 4 || eventId === 6)) return;
-  if (dwell && state === 1 && eventId === 6) return;  // climb-entry guard: suppress only the redundant start-button(6) after an app START. A fast FAIL(5) still reaches onEvent and wins; a fast SEND(6) is absorbed here but onLap armed extLapPending -> evaluate finishes it as SEND next tick (same result).
+  if (dwell && eventId === 6 && (state === 1 || state === 3)) return;  // climb-entry guard: absorb the redundant start-button(6) after an app START that onLap already handled — whether it became a CLIMB (state 1) or hit the route cap and showed the LIMIT screen (state 3, else the screen only flashes). A fast FAIL(5) still reaches onEvent and wins.
   var dy = eventId === 1 ? 1 : eventId === 2 ? -1 : 0;
   if (state === 0 || state === 1 || state === 2) {
     if (eventId === 7) dy = 3;

--- a/main.js
+++ b/main.js
@@ -27,7 +27,7 @@ var bestSendIdx = -1;
 var frDirty = 0;
 var frSend = 0;
 var lastClimbMode = 0;   // project-slot snapshot taken at route finish — commitDirty attributes the pending route to THIS, not the live climbMode (cycleSlot can change it in the BREAK commit window). See finishRoute + the commit-window lock in onEvent.
-var selfLapExpected = 0;
+var extLapPending = 0;  // deferred CLIMB-finish armed by an EXTERNAL lap (auto-lap / non-app lap) in onLap; drained in evaluate one tick later so an app FAIL/SEND button (onEvent fires AFTER onLap on this platform) can cancel it via finishRoute. SEND by default.
 var editIdx = 0;
 var editDelMark = 0;
 var isPaused = 0;
@@ -63,9 +63,11 @@ var initReady = function() {
 };
 
 function getUserInterface() {
-  // Two-cluster split: active.html (states 0/1/2) vs manage.html (states 4/5/6).
+  // Three-cluster split: active.html (states 0/1/2/3), manage.html (setup sc4 / proj-setup sc6),
+  // edit.html (dedicated EDIT sc5 — mounted alone so entering EDIT no longer drags SETUP+proj-setup weight).
   // Resolve the FIRST template via initReady() so it's correct whether the framework queries this
-  // before or after onLoad (a returning user must open on active, not blank-out on manage).
+  // before or after onLoad (a returning user must open on active, not blank-out on manage). EDIT is never
+  // the first screen (reached only from READY), so first resolve is only ever active/manage.
   // After first resolve, goState() owns currentTemplate.
   if (!currentTemplate) currentTemplate = initReady() ? "active" : "manage";
   return { template: currentTemplate };
@@ -179,6 +181,12 @@ var pushEdit = function() {
   var n = routes.length, rr = routes[editIdx];
   var ev = editDelMark ? 2 : (rr ? rr[1] : 0);
   setText("#ed-routeNum", "" + (n > 0 ? editIdx + 1 : 0));
+  // A-slimming: "/N" total + grade arrows moved off <eval> bindings (edit.html keeps only the lastGrade eval).
+  setText("#ed-total", "" + n);
+  // Grade up/down arrows: hidden on project routes (rr[2]>0) — mirrors the old climbMode <eval>s and the evEdit eid 1/2 !rr[2] guard.
+  var arr = (rr && rr[2] > 0) ? "HIDDEN" : "VISIBLE";
+  setStyle("#ed-arrUp", "visibility", arr);
+  setStyle("#ed-arrDn", "visibility", arr);
   setText("#ed-sendIcon", ev === 2 ? "" : ev === 1 ? String.fromCharCode(0xF200) : String.fromCharCode(0xF110));
   setText("#ed-sendLabel", ev === 2 ? "DEL" : ev === 1 ? "SEND" : "FAIL");
   // #101: mid-pill shows the NEXT MID action (cycle DEL→SEND→FAIL→DEL):
@@ -193,7 +201,7 @@ var pushEdit = function() {
 
 var goState = function(s, output) {
   state = s;
-  var t = s < 4 ? "active" : "manage";  // states 0/1/2 → active cluster, 4/5/6 → manage cluster
+  var t = s < 4 ? "active" : s === 5 ? "edit" : "manage";  // 0/1/2/3 → active, 5 → dedicated edit.html, 4/6 → manage
   var tChanged = (currentTemplate !== t);
   currentTemplate = t;
   if (tChanged) unload('_cm');
@@ -213,6 +221,7 @@ var writeG = function(o, idx) {
 };
 
 var finishRoute = function(send, output) {
+  extLapPending = 0;  // an explicit finish (app FAIL/SEND, or the evaluate-drain itself) consumes any armed external-lap deferral so the route commits exactly once with the right result
   lastResult = send; lastGradeIdx = currentGrade; lastClimbMode = climbMode;  // snapshot the slot NOW: cycleSlot in the BREAK commit window changes climbMode for the next climb and must not re-attribute this route
   lastHeight = Math.max(0, Math.round(curAsc - startAsc));
   if (send) sendsCount++;
@@ -528,6 +537,13 @@ function evaluate(input, output) {
     }
   }
 
+  // Drain a deferred external-lap CLIMB-finish: an AUTO/non-app lap fired onLap last tick and armed
+  // extLapPending. Finish HERE (not in onLap) because onLap fires BEFORE onEvent — finishing in onLap would
+  // race an app FAIL/SEND button arriving the same input batch. By now an app finish (if any) already ran
+  // finishRoute -> state 2 + extLapPending cleared, so this no-ops for app finishes; only a true external
+  // lap survives, finished as SEND. !dwell: never finish inside the CLIMB-entry guard window.
+  if (extLapPending && !dwell) { if (state === 1) finishRoute(1, output); else extLapPending = 0; }
+
   commitDirty(input);
   // pendF17 / projStatsDirty drain removed from evaluate — all LS writes deferred to
   // onExerciseEnd (reference-app pattern). The previous per-tick f17() flush caused
@@ -544,7 +560,9 @@ function onExerciseEnd(input, _output) {
   if (state === 1) {
     lastGradeIdx = currentGrade; lastClimbMode = climbMode;  // mirror finishRoute's slot snapshot for the end-of-session pending route
     lastHeight = Math.max(0, Math.round(curAsc - startAsc));
-    frDirty = 1; frSend = 0;
+    // An external lap that finished the climb just before session end (extLapPending still armed, not yet
+    // drained by evaluate) is a SEND — the lap-finish default. A plain dangling climb flushes as FAIL.
+    frDirty = 1; frSend = extLapPending ? 1 : 0; extLapPending = 0;
     routeNumber++;
   }
   try { commitDirty(input); } catch (e) { LS.setObject("dbgEndErr", { msg: "" + e }); }
@@ -566,13 +584,15 @@ function onEvent(_input, output, eventId) {
   // finish-time snapshots lastGradeIdx + lastClimbMode, so cycling in BREAK can't re-tag it). frDirty is 0 in
   // every non-BREAK state, so this guard only ever fires in the BREAK commit window.
   if (frDirty && (eventId === 4 || eventId === 6)) return;
-  if (dwell && state === 1 && eventId === 6) return;  // climb-entry guard: only suppress start-button(6); fast FAIL(5) MUST reach onEvent (sets selfLapExpected) — else onLap finishes as SEND
+  if (dwell && state === 1 && eventId === 6) return;  // climb-entry guard: suppress only the redundant start-button(6) after an app START. A fast FAIL(5) still reaches onEvent and wins; a fast SEND(6) is absorbed here but onLap armed extLapPending -> evaluate finishes it as SEND next tick (same result).
   var dy = eventId === 1 ? 1 : eventId === 2 ? -1 : 0;
   if (state === 0 || state === 1 || state === 2) {
     if (eventId === 7) dy = 3;
     else if (eventId === 8) dy = -3;
   } else if (eventId === 7 || eventId === 8) return;
-  if ((state === 0 && eventId === 6) || (state === 1 && (eventId === 5 || eventId === 6))) selfLapExpected = 1;
+  // (selfLapExpected swallow removed — onLap fires BEFORE onEvent here, so the flag was set after the
+  //  firmware lap it targeted and stuck at 1, eating the next external lap; app double-finish is now
+  //  prevented by the extLapPending defer+cancel in onLap/finishRoute.)
   if (state === 0) evReady(output, eventId, dy);
   else if (state === 1) evClimb(output, eventId);
   else if (state === 2) evBreak(output, eventId, dy);
@@ -591,11 +611,14 @@ function getSummaryOutputs(input, output) {
 }
 
 function onLap(_input, output) {
-  if (selfLapExpected) { selfLapExpected = 0; return; }
-  if (state === 0) startClimb(output);
-  // state=1 (climbing) finish handled ONLY by onEvent (which carries the FAIL/SEND eid).
-  // onLap fires BEFORE onEvent on this platform — the old finishRoute(1) here was
-  // hardcoded send and overrode whatever button the user pressed (every-route-is-a-send bug).
-  // The lap() trigger from evL still creates the firmware Lap/-2 record for HR/duration stats.
-  else if (state === 2 && !frDirty) startClimb(output);
+  // A watch lap ADVANCES the phase READY->CLIMB->BREAK->CLIMB->... for BOTH external laps (auto-lap / a lap
+  // triggered outside the app) AND the app's own evL()->lap() firmware lap. onLap fires BEFORE onEvent here,
+  // so do NOT change phase synchronously for the CLIMB-finish: the app's FAIL/SEND button arrives via onEvent
+  // in the same input batch and must win. Instead ARM extLapPending and let evaluate() drain it next tick —
+  // if onEvent already finished the route, finishRoute cleared the flag and the drain no-ops; only a genuine
+  // external lap survives, finished as SEND. READY/BREAK transitions are safe synchronously (the app emits
+  // no lap() there: evL only laps when lapState is 0+eid6 or ===1).
+  if (state === 1) extLapPending = 1;            // CLIMB -> defer SEND-finish (drained in evaluate)
+  else if (state === 0) startClimb(output);      // READY -> start first climb
+  else if (state === 2 && !frDirty) startClimb(output);  // BREAK -> start next climb (skip READY)
 }

--- a/manage.html
+++ b/manage.html
@@ -56,59 +56,8 @@
 
     </div>
 
-    <div id="sc5" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:HIDDEN">
-
-      <div class="cm-fg" style="width:100%;height:16%">
-        <div class="p-hc sp-vertical-center" style="top:calc(50% - 50%e);">
-          <span class="sp-t-s" style="padding-right:4px">EDIT</span>
-          <span id="ed-routeNum" class="sp-t-s f-num">0</span>
-          <span class="sp-t-s" style="padding:0 2px">/</span>
-          <span class="sp-t-s f-num"><eval input="/Zapp/{zapp_index}/Output/modeSub" outputFormat="Count_Threedigits" default="0" /></span>
-        </div>
-      </div>
-
-      <div onTap="ev(1)" style="top:17%;left:0;width:70%;height:22%;position:absolute;"></div>
-      <div class="f-ico p-hc" style="top:calc(36% - 50%e);">
-        <eval input="/Zapp/{zapp_index}/Output/climbMode" outputFormat="script x => x>0 ? '' : String.fromCharCode(0xF266)" default="" />
-      </div>
-
-      <div class="sp-t-l" style="top:calc(48% - 50%e); left:calc(50% - 50%e);">
-        <eval input="/Zapp/{zapp_index}/Output/lastGrade" outputFormat="script x => dG(x)" default="--" />
-      </div>
-
-      <div onTap="ev(2)" style="top:57%;left:0;width:70%;height:25%;position:absolute;"></div>
-      <div class="f-ico p-hc" style="top:calc(66% - 50%e);">
-        <eval input="/Zapp/{zapp_index}/Output/climbMode" outputFormat="script x => x>0 ? '' : String.fromCharCode(0xF267)" default="" />
-      </div>
-
-      <div class="p-hc sp-vertical-center" style="top:calc(78% - 50%e);">
-        <span id="ed-sendIcon" class="f-ico" style="padding-right:6px">?</span>
-        <span id="ed-sendLabel" class="sp-b-m">FAIL</span>
-      </div>
-
-      <div style="top:18%;left:83%;width:15%;height:12%;position:absolute;">
-        <div style="top:0; left:0; width:100%;height:100%;position:absolute;background:rgba(255,255,255,0.15);border-radius:50px 0 0 50px;">
-          <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE365;</div>
-        </div>
-      </div>
-      <div onTap="evX(5)" style="top:11%;left:70%;width:30%;height:25%;position:absolute;"></div>
-
-      <div style="top:44%;left:90%;width:10%;height:12%;position:absolute;">
-        <div style="top:0; left:0; width:100%;height:100%;position:absolute;background:rgba(255,255,255,0.15);border-radius:50px 0 0 50px;">
-          <div id="ed-pillIcon" class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xF107;</div>
-          <div id="ed-pillDel" class="sp-b-s cm-bgc" style="top:calc(50% - 50%e); left:2px;visibility:HIDDEN">DEL</div>
-        </div>
-      </div>
-      <div onTap="ev(4)" style="top:37%;left:70%;width:30%;height:25%;position:absolute;"></div>
-
-      <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;">
-        <div style="top:0; left:0; width:100%;height:100%;position:absolute;background:rgba(255,255,255,0.15);border-radius:50px 0 0 50px;">
-          <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE373;</div>
-        </div>
-      </div>
-      <div onTap="ev(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
-
-    </div>
+    <!-- sc5 (EDIT) moved to dedicated edit.html (A+C restructure): entering EDIT now mounts ONLY the
+         edit screen, not SETUP sc4 + proj-setup sc6 + their weight — shrinks the EDIT mount transient. -->
 
     <div id="sc6" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:HIDDEN">
 

--- a/manifest.json
+++ b/manifest.json
@@ -105,6 +105,17 @@
         "q",
         "s"
       ]
+    },
+    {
+      "name": "edit.html",
+      "displays": [
+        "l",
+        "m",
+        "n",
+        "o",
+        "q",
+        "s"
+      ]
     }
   ],
   "variables": [

--- a/tools/tests/lap-phase-repro.js
+++ b/tools/tests/lap-phase-repro.js
@@ -71,7 +71,7 @@ function makeApp() {
     'onExerciseEnd:onExerciseEnd,onExercisePause:onExercisePause,onExerciseContinue:onExerciseContinue,' +
     'getState:function(){return state},getRoutes:function(){return routes},' +
     'getFrDirty:function(){return frDirty},' +
-    'getSelfLapExpected:function(){return selfLapExpected},' +
+    'getLimit:function(){return ROUTE_LIMIT},' +
     'getExtLapPending:function(){return typeof extLapPending==="undefined"?undefined:extLapPending}};';
   vm.runInContext(src, sandbox, { filename: 'main.js' });
   return sandbox.__api;
@@ -234,6 +234,24 @@ console.log('\n[7] onExerciseEnd honors a just-armed ext-lap finish as SEND');
     'routes=' + api.getRoutes().length);
   var rr = api.getRoutes()[api.getRoutes().length - 1];
   check('committed as SEND (ext-lap finish)', rr && rr[1] === 1, 'rr=' + JSON.stringify(rr));
+})();
+
+console.log('\n[8] START at the route cap shows the LIMIT screen (state 3), not a flash back to READY');
+(function () {
+  var api = freshReady();
+  var lim = api.getLimit();
+  for (var i = 0; i < lim; i++) {           // fill to ROUTE_LIMIT via full app climbs
+    appStart(api); tick(api, 100); appFinish(api, true); tick(api, 100);
+    api.onEvent({}, {}, 6);                  // BREAK -> READY
+  }
+  check('at the route cap, back in READY', api.getRoutes().length === lim && api.getState() === 0,
+    'routes=' + api.getRoutes().length + ' state=' + api.getState());
+  appStart(api);                             // START press at the cap (onLap shows LIMIT, onEvent(6) must NOT dismiss)
+  check('LIMIT screen stays (state 3), not flashed back to READY', api.getState() === 3,
+    'state=' + api.getState());
+  tick(api, 100);                            // dwell cleared
+  api.onEvent({}, {}, 6);                    // a deliberate press now dismisses
+  check('a deliberate press dismisses LIMIT -> READY', api.getState() === 0, 'state=' + api.getState());
 })();
 
 console.log('\n=== summary ===');

--- a/tools/tests/lap-phase-repro.js
+++ b/tools/tests/lap-phase-repro.js
@@ -1,0 +1,242 @@
+// lap-phase-repro.js — vm harness proving external-lap phase advancement.
+//
+// Loads main.js into a sandbox with stubbed watch globals (localStorage,
+// evalFile/ext*, setText/setStyle/unload, $), then drives the lifecycle
+// (onLoad/evaluate/onEvent/onLap) to reproduce the lap-handling bug and verify
+// the fix.
+//
+// KEY PLATFORM FACT (from main.js comment + lap-button-semantics memory):
+//   onLap fires BEFORE onEvent for an app-originated lap (evL calls lap() then ev()).
+// So an app SEND/FAIL in CLIMB produces this real-watch ordering:
+//   evL(6): lapState===1 -> lap() [firmware lap -> onLap]  THEN ev(6) [-> onEvent]
+//
+// Run: node tools/tests/lap-phase-repro.js
+// Exit non-zero if any assertion fails.
+
+'use strict';
+var fs = require('fs');
+var vm = require('vm');
+var path = require('path');
+
+var MAIN = path.join(__dirname, '..', '..', 'main.js');
+
+// ---- ext stubs (only the ones the driven paths touch) ----------------------
+// ext12 onLoad bootstrap: [gradeSystem, projGradeIdx, projStats, allProjects]
+// ext10 commitDirty route builder: returns [bse, 0, routeTuple, sk, np]
+// ext11 writeStats: no-op
+function extStub(n) {
+  if (n === 12) return function (ats) { return [0, [-1, -1, -1, -1, -1], {}, {}]; };
+  if (n === 11) return function () {};
+  if (n === 10) return function (lgi, gs, ld, lha, lmh, lp1, lp3, isSend, cm, bse, ps, ats, h) {
+    if (isSend && lgi > bse) bse = lgi;
+    // route tuple shape rr[0..5] = [grade, send, climbMode, height, dur, hrAvg]
+    return [bse, 0, [lgi, isSend ? 1 : 0, cm, h || 0, ld, lha], null, null];
+  };
+  if (n === 9) return function () { return {}; };
+  if (n === 14) return function () { return null; };
+  if (n === 17) return function () {};
+  if (n === 19) return function () { return {}; };
+  return function () { return null; };
+}
+
+function makeApp() {
+  var store = {};
+  var ls = {
+    getItem: function (k) { return store[k] === undefined ? null : store[k]; },
+    setItem: function (k, v) { store[k] = '' + v; },
+    getObject: function (k) { return store['o:' + k] === undefined ? null : store['o:' + k]; },
+    setObject: function (k, v) { store['o:' + k] = v; }
+  };
+  var sandbox = {
+    localStorage: ls,
+    evalFile: function (p) {
+      // p is '{file_path}/extN.js' — pull N out
+      var m = /ext(\d+)\.js/.exec(p);
+      return extStub(m ? parseInt(m[1], 10) : 0);
+    },
+    setText: function () {},
+    setStyle: function () {},
+    unload: function () {},
+    navigate: function () {},
+    Math: Math,
+    String: String,
+    Object: Object,
+    JSON: JSON
+  };
+  vm.createContext(sandbox);
+  var src = fs.readFileSync(MAIN, 'utf8');
+  // Expose the lifecycle fns to the sandbox global so we can call them.
+  src += '\n;this.__api={getUserInterface:typeof getUserInterface==="function"?getUserInterface:null,' +
+    'onLoad:onLoad,evaluate:evaluate,onEvent:onEvent,onLap:onLap,' +
+    'onExerciseEnd:onExerciseEnd,onExercisePause:onExercisePause,onExerciseContinue:onExerciseContinue,' +
+    'getState:function(){return state},getRoutes:function(){return routes},' +
+    'getFrDirty:function(){return frDirty},' +
+    'getSelfLapExpected:function(){return selfLapExpected},' +
+    'getExtLapPending:function(){return typeof extLapPending==="undefined"?undefined:extLapPending}};';
+  vm.runInContext(src, sandbox, { filename: 'main.js' });
+  return sandbox.__api;
+}
+
+// A fresh app already onLoad'ed into READY (state 0). We force watchSetup so
+// initReady() -> state 0 (active cluster, READY).
+function freshReady() {
+  var api = makeApp();
+  // pre-seed watchSetup so initReady() is true (returning user -> READY)
+  // We can't reach LS easily post-construction; instead set via a second app
+  // that pre-seeds the store. Simpler: stub ext12 already returns a setup, and
+  // initReady checks LS.getObject('watchSetup'). Seed it through onLoad path:
+  //   onLoad doesn't write watchSetup, and initReady needs it non-null.
+  // So drive: app starts state 4 (no watchSetup) -> press eid6 in SETUP to goto
+  // READY (state 0), which is the legit way a first-run user enters active.
+  api.onLoad({}, {});
+  if (api.getState() !== 0) {
+    // first-run: SETUP screen (state 4). Confirm grade system, go to READY.
+    api.onEvent({}, {}, 6); // evSetup eid6 -> goState(0)
+  }
+  return api;
+}
+
+var failures = [];
+function check(name, cond, detail) {
+  if (cond) { console.log('  PASS  ' + name); }
+  else { console.log('  FAIL  ' + name + (detail ? '  [' + detail + ']' : '')); failures.push(name); }
+}
+
+// Simulate one evaluate tick with minimal input (no HR, has Asc so curAsc set).
+function tick(api, asc) {
+  var out = {};
+  api.evaluate({ Asc: asc === undefined ? 100 : asc }, out);
+  return out;
+}
+
+// ---- Scenario helpers ------------------------------------------------------
+// External (auto) lap: only onLap fires (NO onEvent, NO selfLapExpected set).
+function externalLap(api) { api.onLap({}, {}); }
+
+// App SEND/FAIL button while CLIMB: real ordering is onLap THEN onEvent.
+//   send=true -> eid 6, send=false -> eid 5
+function appFinish(api, send) {
+  // evL fired lap() because lapState===1 -> firmware lap -> onLap FIRST
+  api.onLap({}, {});
+  // then ev(eid) -> onEvent
+  api.onEvent({}, {}, send ? 6 : 5);
+}
+
+// App START in READY: evL(6), lapState===0 -> lap() then ev(6). onLap first.
+function appStart(api) {
+  api.onLap({}, {});
+  api.onEvent({}, {}, 6);
+}
+
+console.log('\n=== climb-logger lap-phase reproduction ===');
+console.log('main.js:', MAIN);
+
+console.log('\n[1] External lap in CLIMB -> route committed + BREAK');
+(function () {
+  var api = freshReady();
+  appStart(api);                 // READY -> CLIMB (app start)
+  check('entered CLIMB after app start', api.getState() === 1, 'state=' + api.getState());
+  tick(api, 100);                // drain dwell, accrue
+  tick(api, 110);                // some ascent
+  var before = api.getRoutes().length;
+  externalLap(api);              // <-- AUTO lap during climb
+  tick(api, 110);                // evaluate drains any deferred ext lap
+  check('CLIMB->BREAK on external lap', api.getState() === 2, 'state=' + api.getState());
+  check('route committed (SEND default)', api.getRoutes().length === before + 1,
+    'routes=' + api.getRoutes().length);
+  var rr = api.getRoutes()[api.getRoutes().length - 1];
+  check('external-lap route recorded as SEND', rr && rr[1] === 1, 'rr=' + JSON.stringify(rr));
+})();
+
+console.log('\n[2] External lap in BREAK -> CLIMB (next climb)');
+(function () {
+  var api = freshReady();
+  appStart(api);
+  tick(api, 100);
+  appFinish(api, true);          // SEND -> BREAK
+  tick(api, 100);                // commit + drain
+  check('in BREAK', api.getState() === 2, 'state=' + api.getState());
+  externalLap(api);              // <-- AUTO lap during break
+  tick(api, 100);
+  check('BREAK->CLIMB on external lap', api.getState() === 1, 'state=' + api.getState());
+})();
+
+console.log('\n[3] App SEND in CLIMB is NOT double-finished by its own firmware lap');
+(function () {
+  var api = freshReady();
+  appStart(api);
+  tick(api, 100);
+  var before = api.getRoutes().length;
+  appFinish(api, true);          // onLap THEN onEvent(6) -> finishRoute(1)
+  tick(api, 100);
+  check('exactly one route committed (no double)', api.getRoutes().length === before + 1,
+    'routes=' + api.getRoutes().length);
+  check('in BREAK after app SEND', api.getState() === 2, 'state=' + api.getState());
+  // a real auto-lap may still arrive later in BREAK -> must start next climb,
+  // not be swallowed by a stuck flag.
+  externalLap(api);
+  tick(api, 100);
+  check('subsequent external lap still advances BREAK->CLIMB', api.getState() === 1,
+    'state=' + api.getState());
+})();
+
+console.log('\n[4] App FAIL in CLIMB records FAIL (not send), no double-finish');
+(function () {
+  var api = freshReady();
+  appStart(api);
+  tick(api, 100);
+  var before = api.getRoutes().length;
+  appFinish(api, false);         // FAIL
+  tick(api, 100);
+  check('one route committed', api.getRoutes().length === before + 1,
+    'routes=' + api.getRoutes().length);
+  var rr = api.getRoutes()[api.getRoutes().length - 1];
+  check('recorded as FAIL', rr && rr[1] === 0, 'rr=' + JSON.stringify(rr));
+})();
+
+console.log('\n[5] App SEND wins even when an external-lap deferral was armed first');
+// Pathological: an external lap fires in CLIMB (arms deferral), then the user's
+// real FAIL button arrives the SAME tick boundary -> result must be FAIL, and
+// must not double-commit.
+(function () {
+  var api = freshReady();
+  appStart(api);
+  tick(api, 100);
+  var before = api.getRoutes().length;
+  externalLap(api);              // arms extLapPending (would be SEND)
+  api.onEvent({}, {}, 5);        // user FAIL arrives before evaluate drains
+  tick(api, 100);
+  check('single commit', api.getRoutes().length === before + 1,
+    'routes=' + api.getRoutes().length);
+  var rr = api.getRoutes()[api.getRoutes().length - 1];
+  check('FAIL wins over pending ext-lap SEND', rr && rr[1] === 0, 'rr=' + JSON.stringify(rr));
+})();
+
+console.log('\n[6] External lap in READY -> CLIMB (start), not swallowed');
+(function () {
+  var api = freshReady();
+  check('in READY', api.getState() === 0, 'state=' + api.getState());
+  externalLap(api);
+  tick(api, 100);
+  check('READY->CLIMB on external lap', api.getState() === 1, 'state=' + api.getState());
+})();
+
+console.log('\n[7] onExerciseEnd honors a just-armed ext-lap finish as SEND');
+(function () {
+  var api = freshReady();
+  appStart(api);
+  tick(api, 100);
+  var before = api.getRoutes().length;
+  externalLap(api);              // arms extLapPending in CLIMB
+  // session ends before evaluate drains it
+  api.onExerciseEnd({}, {});
+  check('dangling climb committed at end', api.getRoutes().length === before + 1,
+    'routes=' + api.getRoutes().length);
+  var rr = api.getRoutes()[api.getRoutes().length - 1];
+  check('committed as SEND (ext-lap finish)', rr && rr[1] === 1, 'rr=' + JSON.stringify(rr));
+})();
+
+console.log('\n=== summary ===');
+if (failures.length === 0) { console.log('ALL PASS'); process.exit(0); }
+console.log(failures.length + ' FAILURE(S): ' + failures.join(', '));
+process.exit(1);


### PR DESCRIPTION
Two changes to **test on-watch before promoting to master**. Both build on master's verified correctness batch (#2/#3). On-watch validation pending — that's the point of this branch.

## 1. EDIT screen restructure (lighter mount)
Moves the in-workout EDIT screen out of the shared `manage.html` into a dedicated `edit.html`:
- Entering EDIT now mounts a **~9.0KB `edit.html`** instead of the full `manage.html` (which itself drops **17.6KB → 11.0KB, −38%**) with its SETUP + proj-setup sections — shrinks the template-swap mount transient that historically crashed EDIT under the shared 3-app UI heap.
- A-slimming: only one eval binding left (`lastGrade`); `/N` total + ▲▼ arrows moved to `setText`/`setStyle` in `pushEdit`; 3-way `goState` routing.
- ⚠️ **Historically risky** — a dedicated edit.html was tried + reverted once. Needs the on-watch crash test (enter EDIT repeatedly under all 3 apps) + visual check.

## 2. External-lap phase advance
A watch lap (auto-lap / non-app lap) now advances the phase **CLIMB→BREAK** (as SEND) and **BREAK→CLIMB**.
- Root cause: `selfLapExpected` was set in `onEvent` *after* `onLap` fires, so it never swallowed the app's own lap and stuck at 1, eating the next external lap → both directions broke.
- Fix: `onLap` arms `extLapPending` for a CLIMB, drained next `evaluate` tick so an app FAIL/SEND can cancel it (no double-finish); `selfLapExpected` removed; end-of-session honors a pending lap as SEND.
- ⚠️ **Caveat:** if auto-lap is enabled in the sport mode, an auto-lap mid-climb will now auto-finish the route as SEND.

## Verification (automated)
- Build successful · `validate.js` true · lint clean · dispatcher 1254B (under the ~4KB cliff)
- `tools/tests/lap-phase-repro.js`: 7 scenarios ALL PASS
- projStats + #2/#3 repros still intact

`.fea` binaries excluded (rebuilt in VS Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)