### PR TITLE
perf: pack active.html outputs (grade+lastGrade, break trio) — shrink swipe-mount footprint

### DIFF
--- a/active.html
+++ b/active.html
@@ -42,7 +42,7 @@
       <div class="f-ico p-hc" style="top:calc(36% - 50%e);">&#xF266;</div>
 
       <div class="sp-t-l" style="top:calc(48% - 50%e); left:calc(50% - 50%e);">
-        <eval input="/Zapp/{zapp_index}/Output/grade" outputFormat="script x => dG(x)" default="--" />
+        <eval input="/Zapp/{zapp_index}/Output/packedGL" outputFormat="script x => dG(Math.floor(x/952))" default="--" />
       </div>
 
       <div onTap="ev(2)" style="top:57%;left:0;width:70%;height:25%;position:absolute;"></div>
@@ -104,7 +104,7 @@
 
       <div class="sp-vertical-center" style="top:calc(55% - 50%e); left:calc(70% - 50%e);">
         <span class="f-ico" style="padding-right:4px">&#xF144;</span>
-        <span class="sp-b-m"><eval input="/Zapp/{zapp_index}/Output/grade" outputFormat="script x => dG(x)" default="--" /></span>
+        <span class="sp-b-m"><eval input="/Zapp/{zapp_index}/Output/packedGL" outputFormat="script x => dG(Math.floor(x/952))" default="--" /></span>
       </div>
 
       <div class="sp-vertical-center" style="top:calc(72% - 50%e); left:calc(45% - 50%e);">
@@ -138,7 +138,7 @@
 
       <div class="sp-vertical-center" style="top:calc(27% - 50%e); left:calc(30% - 50%e);">
         <span class="f-ico" style="padding-right:4px">&#xF144;</span>
-        <span class="sp-b-m"><eval input="/Zapp/{zapp_index}/Output/lastGrade" outputFormat="script x => dG(x)" default="--" /></span>
+        <span class="sp-b-m"><eval input="/Zapp/{zapp_index}/Output/packedGL" outputFormat="script x => dG(x%952-1)" default="--" /></span>
       </div>
 
       <div class="p-hc" style="top:22%;width:2px;height:14%;background:rgba(255,255,255,0.3)"></div>
@@ -173,9 +173,9 @@
       <div class="p-hc sp-vertical-center" style="top:calc(64% - 50%e);">
         <span class="f-ico" style="padding-right:14px">&#xF107;</span>
         <span class="f-ico" style="padding-right:6px">&#xF200;</span>
-        <span class="sp-b-s f-num"><eval input="/Zapp/{zapp_index}/Output/brkSends" outputFormat="script x => ''+x" default="0" /></span><span class="sp-b-s f-num">/</span><span class="sp-b-s f-num"><eval input="/Zapp/{zapp_index}/Output/brkRoutes" outputFormat="script x => ''+x" default="0" /></span>
+        <span class="sp-b-s f-num"><eval input="/Zapp/{zapp_index}/Output/packedBreak" outputFormat="script x => ''+(Math.floor(x/64)%64)" default="0" /></span><span class="sp-b-s f-num">/</span><span class="sp-b-s f-num"><eval input="/Zapp/{zapp_index}/Output/packedBreak" outputFormat="script x => ''+(x%64)" default="0" /></span>
         <span class="f-ico" style="padding-left:16px;padding-right:6px">&#xF118;</span>
-        <span class="sp-b-s"><eval input="/Zapp/{zapp_index}/Output/bestSend" outputFormat="script x => dG(x)" default="--" /></span>
+        <span class="sp-b-s"><eval input="/Zapp/{zapp_index}/Output/packedBreak" outputFormat="script x => dG(Math.floor(x/4096)-1)" default="--" /></span>
         <span class="sp-b-s" style="padding-left:16px">H</span>
         <span class="sp-b-s f-num" style="padding-left:3px"><eval input="/Zapp/{zapp_index}/Output/routeHeight" outputFormat="script x => (x>=0?'+':'') + x + 'm'" default="--" /></span>
       </div>

--- a/edit.html
+++ b/edit.html
@@ -31,7 +31,7 @@
       <div id="ed-arrUp" class="f-ico p-hc" style="top:calc(36% - 50%e);">&#xF266;</div>
 
       <div class="sp-t-l" style="top:calc(48% - 50%e); left:calc(50% - 50%e);">
-        <eval input="/Zapp/{zapp_index}/Output/lastGrade" outputFormat="script x => dG(x)" default="--" />
+        <eval input="/Zapp/{zapp_index}/Output/packedGL" outputFormat="script x => dG(x%952-1)" default="--" />
       </div>
 
       <div onTap="ev(2)" style="top:57%;left:0;width:70%;height:25%;position:absolute;"></div>

--- a/main.js
+++ b/main.js
@@ -117,10 +117,13 @@ var cycleSlot = function(dy) {
 
 // Output packing — shrink active.html's mount footprint (fewer distinct WB path subscriptions coexist
 // during the inter-app swipe = template-swap peak that evicts the app; see crash-template-swap-eviction).
-//   packedGL    = grade + lastGrade            → 1 path (was 2). max 940*952+941 = 895,821 < 2^24.
-//   packedBreak = bestSend + brkSends + brkRoutes → 1 path (was 3). base-64; counts saturate at 63
-//                 (ROUTE_LIMIT test build logs >35; prod cap 35 / splice 50). max 941*4096+63*64+63 = 3,858,431 < 2^24.
+//   packedGL    = grade*952 + (lastGrade+1)        → 1 path (was 2). grade-field max = encGrade(50) OFF
+//                 sentinel = 950 (gradeSystem 9): 950*952 = 904,400 < 2^24.
+//   packedBreak = (bestSend+1)*4096 + brkSends*64 + brkRoutes → 1 path (was 3). base-64; counts saturate at
+//                 63 (ROUTE_LIMIT test build logs >35; prod cap 35 / splice 50). max (900+1)*4096+63*64+63 = 3,694,591 < 2^24.
 // Outputs reach template scripts as FLOAT32, so each composite stays <= 2^24 (16.7M); see outputs-are-float32.
+// DECODE SITES (bare literals, NOT build-checked — change in lockstep): active.html (grade/lastGrade/brkSends/
+// brkRoutes/bestSend), manage.html (grade), edit.html (lastGrade), tools/tests/output-pack-equiv.js (the equiv proof).
 // Mirrors hold the latest component so any single-component write republishes the WHOLE composite (a
 // SuuntoPlus output publishes whole — a partial write would zero the other fields). vState stays its own
 // output: it drives applyVis in active+manage, and packing it would re-fire applyVis on every grade change.
@@ -140,7 +143,7 @@ var pushMode = function(o) {
 
 var setOutputs = function(output) {
   output.vState = state;
-  lastGradeV = lastGradeIdx >= 0 ? encGrade(lastGradeIdx) : -1; wGL(output);
+  lastGradeV = lastGradeIdx >= 0 ? encGrade(lastGradeIdx) : -1;  // no wGL() here: every state path below republishes packedGL (4/5/6 explicitly, else via writeG) — a wGL now would just be overwritten, an extra publish per tick
   output.routePk1 = lastPk1;
   output.routePk3 = lastPk3;
   output.routeHeight = state === 1 ? Math.max(0, Math.round(curAsc - startAsc)) : sessionH;  // CLIMB shows the CURRENT route's live height only; other screens show the session total
@@ -185,7 +188,7 @@ var writeActStats = function(output) {
 };
 
 // pushBrk / pushActStats removed — break counter + project stats migrated to output
-// bindings (brkSends/brkRoutes/actT/actS/actB). setText on a HIDDEN section is a
+// bindings (packedBreak's brkSends/brkRoutes fields + actT/actS/actB). setText on a HIDDEN section is a
 // silent no-op on this platform; sc0/sc2 are still hidden when goState(N) runs
 // from the event handler (applyVis(N) is async via the vState output binding).
 
@@ -219,7 +222,7 @@ var goState = function(s, output) {
   currentTemplate = t;
   if (tChanged) unload('_cm');
   if (s === 1 || s === 3) dwell = 1;  // s===3 (LIMIT) too: a START at the route cap goes onLap->startClimb->goState(3); the trailing onEvent(6) from the SAME press must be absorbed (dwell) or it immediately goState(0)s and the LIMIT screen only flashes
-  if (output) setOutputs(output);  // publishes actT/actS/actB (s=0) and brkSends/brkRoutes (s=2)
+  if (output) setOutputs(output);  // publishes actT/actS/actB (s=0) and packedBreak brkSends/brkRoutes fields (s=2)
   // climbProjStats write removed from goState(0) — was a mid-session LS write that
   // triggered ~0.5s flash-GC freezes on break→ready in project mode. Unconditional
   // write at onExerciseEnd covers it (psA/psB-equivalent persisted only at session end).
@@ -318,7 +321,7 @@ var commitDirty = function(input) {
       sessionH += lastHeight || 0;
     }
     hrIdx = hr1Sum = hr3Sum = bestPk1 = bestPk3 = hrSum = hrCnt = hrMax = rSec = 0;
-    // brkSends/brkRoutes/actT/actS/actB updated by setOutputs (called at end of evaluate).
+    // packedBreak (brkSends/brkRoutes fields) + actT/actS/actB updated by setOutputs (called at end of evaluate).
   }
 };
 

--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@ var state = 4;
 var currentGrade = 18;
 var routeNumber = 1;
 var routes = [];
+var routesEvicted = 0;   // set to 1 once commitDirty splices routes[] past 50 (only reachable when ROUTE_LIMIT > the splice cap, e.g. the 999 TEMP build) — routes[] is then incomplete, so rescanBest must not recompute a slot best from it
 var sendsCount = 0;
 var lastResult = 0;
 
@@ -132,7 +133,7 @@ var brkSendsV = 0, brkRoutesV = 0;
 var wGL = function(o) { o.packedGL = gradeV * 952 + (lastGradeV + 1); };
 var wBrk = function(o) {
   var bse = bestSendIdx >= 0 ? encGrade(bestSendIdx) : -1;
-  o.packedBreak = (bse + 1) * 4096 + (brkSendsV > 63 ? 63 : brkSendsV) * 64 + (brkRoutesV > 63 ? 63 : brkRoutesV);
+  o.packedBreak = (bse + 1) * 4096 + Math.max(0, Math.min(63, brkSendsV)) * 64 + Math.max(0, Math.min(63, brkRoutesV));  // symmetric clamp: a negative count would otherwise borrow into the bestSend field, not just its own
 };
 
 var pushMode = function(o) {
@@ -284,11 +285,13 @@ var recalcBse = function() {
 };
 
 // Recompute a project slot's bestTime from this session's routes — call after deleting/un-sending a route
-// that may have held the slot's best, else a stale orphaned best survives forever. Gated on
-// firstSes===sessions: only sound when ALL the slot's routes are in this session's in-memory routes[]
-// (true here — ROUTE_LIMIT 35 < the 50-route splice cap, so same-session routes are never evicted).
+// that may have held the slot's best, else a stale orphaned best survives forever. Sound ONLY when ALL the
+// slot's routes are still in the in-memory routes[]: gated on firstSes===sessions (a first-session slot) AND
+// !routesEvicted. At ROUTE_LIMIT 35 the 50-route splice can't fire, but the 999 TEMP build can log past 50,
+// evicting the earliest routes — a recompute would then miss the slot's true (faster, evicted) best and
+// overwrite the correctly-recorded bestTime with a too-high/0 value that persists to flash. Bail instead.
 var rescanBest = function(cm) {
-  if (cm <= 0) return;
+  if (cm <= 0 || routesEvicted) return;
   var p = projStats[gradeSystem + "_" + cm];
   if (!p || p.firstSes !== allTimeStats.sessions) return;
   var best = 0;
@@ -313,7 +316,7 @@ var commitDirty = function(input) {
     bestSendIdx = r[0];
     if (r[2]) {
       routes.push(r[2]);
-      if (routes.length > 50) routes.splice(0, routes.length - 50);
+      if (routes.length > 50) { routes.splice(0, routes.length - 50); routesEvicted = 1; }  // routes[] now incomplete → rescanBest must not trust it (see its guard)
       allTimeStats.totalRoutes++;
       if (frSend) allTimeStats.totalSends++;
       recPct();

--- a/main.js
+++ b/main.js
@@ -48,7 +48,7 @@ var wsDirty = 0;         // gradeSystem/projGradeIdx diverge from watchSetup on 
 var allTimeStats = { totalRoutes: 0, totalSends: 0, sendPct: 0, sessions: 0, totalHeight: 0 };
 
 var GRADE_LENS = [41, 24, 29, 11, 14, 30, 11, 12, 1, 1];
-var ROUTE_LIMIT = 35;  // in-session route cap — at this many logged routes, block new climbs and show the LIMIT screen (state 3). Save+restart resets per-session heap/subscriptions: the safety valve for the shared 3-app path/heap ceiling that crashes long multi-app sessions.
+var ROUTE_LIMIT = 999;  // TEMP TEST (was 35) — cap disabled so the swipe-crash ceiling can be probed past 35 with the new output-packing. REVERT to 35 before merge. packedBreak counts saturate at 63, so brk display is only exact <=63 routes (irrelevant to the crash measurement). Normal: in-session cap → LIMIT screen (state 3), save+restart resets per-session heap/subscriptions.
 var DEFAULT_IDX = [18, 6, 5, 5, 4, 12, 3, 5, 0, 0];
 var gradeSystem = 0;
 var LS = localStorage;
@@ -115,8 +115,21 @@ var cycleSlot = function(dy) {
   if (projGradeIdx[next - 1] >= 0) currentGrade = projGradeIdx[next - 1];
 };
 
-var pushBest = function(o) {
-  o.bestSend = bestSendIdx >= 0 ? encGrade(bestSendIdx) : -1;
+// Output packing — shrink active.html's mount footprint (fewer distinct WB path subscriptions coexist
+// during the inter-app swipe = template-swap peak that evicts the app; see crash-template-swap-eviction).
+//   packedGL    = grade + lastGrade            → 1 path (was 2). max 940*952+941 = 895,821 < 2^24.
+//   packedBreak = bestSend + brkSends + brkRoutes → 1 path (was 3). base-64; counts saturate at 63
+//                 (ROUTE_LIMIT test build logs >35; prod cap 35 / splice 50). max 941*4096+63*64+63 = 3,858,431 < 2^24.
+// Outputs reach template scripts as FLOAT32, so each composite stays <= 2^24 (16.7M); see outputs-are-float32.
+// Mirrors hold the latest component so any single-component write republishes the WHOLE composite (a
+// SuuntoPlus output publishes whole — a partial write would zero the other fields). vState stays its own
+// output: it drives applyVis in active+manage, and packing it would re-fire applyVis on every grade change.
+var gradeV = 0, lastGradeV = -1;
+var brkSendsV = 0, brkRoutesV = 0;
+var wGL = function(o) { o.packedGL = gradeV * 952 + (lastGradeV + 1); };
+var wBrk = function(o) {
+  var bse = bestSendIdx >= 0 ? encGrade(bestSendIdx) : -1;
+  o.packedBreak = (bse + 1) * 4096 + (brkSendsV > 63 ? 63 : brkSendsV) * 64 + (brkRoutesV > 63 ? 63 : brkRoutesV);
 };
 
 var pushMode = function(o) {
@@ -127,36 +140,36 @@ var pushMode = function(o) {
 
 var setOutputs = function(output) {
   output.vState = state;
-  output.lastGrade = lastGradeIdx >= 0 ? encGrade(lastGradeIdx) : -1;
+  lastGradeV = lastGradeIdx >= 0 ? encGrade(lastGradeIdx) : -1; wGL(output);
   output.routePk1 = lastPk1;
   output.routePk3 = lastPk3;
   output.routeHeight = state === 1 ? Math.max(0, Math.round(curAsc - startAsc)) : sessionH;  // CLIMB shows the CURRENT route's live height only; other screens show the session total
   output.climbMode = climbMode;
   if (state === 5) {
     var rr = routes[editIdx];
-    output.lastGrade = rr ? encGrade(rr[0]) : -1;
+    lastGradeV = rr ? encGrade(rr[0]) : -1; wGL(output);
     output.modeSub = routes.length;
     output.climbMode = rr ? (rr[2] || 0) : 0;
     return;
   } else if (state === 6) {
-    output.grade = projGradeIdx[pStep] >= 0 ? encGrade(projGradeIdx[pStep]) : encGrade(50);
+    gradeV = projGradeIdx[pStep] >= 0 ? encGrade(projGradeIdx[pStep]) : encGrade(50);
     output.modeSub = pStep + 1;
-    output.lastGrade = -1;
+    lastGradeV = -1; wGL(output);
   } else if (state === 4) {
-    output.grade = encGrade(DEFAULT_IDX[gradeSystem]);
+    gradeV = encGrade(DEFAULT_IDX[gradeSystem]);
     output.modeSub = gradeSystem;
-    output.lastGrade = -1;
+    lastGradeV = -1; wGL(output);
   } else {
     var rn = state === 2 ? routeNumber - 1 : routeNumber;
     writeG(output, climbMode > 0 ? climbMode - 1 : undefined);
     output.modeSub = climbMode > 0 ? -climbMode : rn;
-    // Break counter — output bindings (setText was a no-op while sc2 still HIDDEN when goState(2) ran)
-    if (state === 2) { output.brkSends = sendsCount; output.brkRoutes = rn; }
+    // Break counter — packed into packedBreak via wBrk (setText was a no-op while sc2 still HIDDEN when goState(2) ran)
+    if (state === 2) { brkSendsV = sendsCount; brkRoutesV = rn; }
     // Project stats line on ready screen — output bindings (same hidden-sc0 reason)
     if (state === 0) writeActStats(output);
     else { output.actT = -1; output.actS = -1; output.actB = -1; }
   }
-  pushBest(output);
+  wBrk(output);
 };
 
 // Project stats line — output bindings (setText on hidden sc0 is a no-op).
@@ -217,7 +230,8 @@ var goState = function(s, output) {
 };
 
 var writeG = function(o, idx) {
-  o.grade = encGrade(idx === undefined ? currentGrade : projGradeIdx[idx] >= 0 ? projGradeIdx[idx] : 50);
+  gradeV = encGrade(idx === undefined ? currentGrade : projGradeIdx[idx] >= 0 ? projGradeIdx[idx] : 50);
+  wGL(o);
 };
 
 var finishRoute = function(send, output) {
@@ -377,11 +391,11 @@ var evBreak = function(output, eid, dy) {
       // routes[len-1] is the PREVIOUS route — editing it here corrupts it. The pending route picks
       // up the corrected lastGradeIdx on push, so skip the array write until it's committed.
       if (routes.length > 0 && !frDirty) routes[routes.length - 1][0] = lastGradeIdx;
-      output.lastGrade = encGrade(lastGradeIdx);
-      writeG(output);
+      lastGradeV = encGrade(lastGradeIdx);
+      writeG(output);  // publishes packedGL with the new gradeV + lastGradeV
       if (lastResult) {
         recalcBse();
-        pushBest(output);
+        wBrk(output);
       }
     }
   } else if (eid === 4) {
@@ -396,7 +410,7 @@ var evSetup = function(output, eid, dy) {
     gradeSystem = (gradeSystem + dy + 10) % 10;
     currentGrade = DEFAULT_IDX[gradeSystem];
     loadProjects(gradeSystem);
-    output.grade = encGrade(DEFAULT_IDX[gradeSystem]);
+    gradeV = encGrade(DEFAULT_IDX[gradeSystem]); wGL(output);
     output.modeSub = gradeSystem;
     wsDirty = 1;   // watchSetup needs persisting at session end
     pendF17 = 1;   // ext17 grade-system snapshot swap also runs at session end
@@ -409,14 +423,14 @@ var evSetup = function(output, eid, dy) {
 var evProjSetup = function(output, eid, dy) {
   if (dy) {
     projGradeIdx[pStep] = wrap(projGradeIdx[pStep] + dy, GRADE_LENS[gradeSystem], 1);
-    output.grade = projGradeIdx[pStep] >= 0 ? encGrade(projGradeIdx[pStep]) : encGrade(50);
+    gradeV = projGradeIdx[pStep] >= 0 ? encGrade(projGradeIdx[pStep]) : encGrade(50); wGL(output);
     output.modeSub = pStep + 1;
     wsDirty = 1;   // watchSetup needs persisting at session end
   } else if (eid === 5) {
     goState(0, output);  // instant — saveSetup deferred to onExerciseEnd
   } else if (eid === 6) {
     pStep = (pStep + 1) % 5;
-    output.grade = projGradeIdx[pStep] >= 0 ? encGrade(projGradeIdx[pStep]) : encGrade(50);
+    gradeV = projGradeIdx[pStep] >= 0 ? encGrade(projGradeIdx[pStep]) : encGrade(50); wGL(output);
     output.modeSub = pStep + 1;
   }
 };
@@ -453,7 +467,7 @@ var evEdit = function(output, eid) {
       editIdx = (editIdx - 1 + n) % n;
       var pr = routes[editIdx];
       if (pr) {
-        output.lastGrade = encGrade(pr[0]);
+        lastGradeV = encGrade(pr[0]); wGL(output);
         output.modeSub = n;
         output.climbMode = pr[2] || 0;
       }
@@ -490,7 +504,7 @@ var evEdit = function(output, eid) {
       }
       recPct();
       recalcBse();
-      pushBest(output);
+      wBrk(output);
       pushEdit();  // T6: editSend icons/label moved to setText
     }
   } else if (eid === 1 || eid === 2) {
@@ -498,10 +512,10 @@ var evEdit = function(output, eid) {
     if (rr && !rr[2]) {
       var dy5 = eid === 1 ? 1 : -1, L = GRADE_LENS[gradeSystem];
       rr[0] = ((rr[0] + dy5) % L + L) % L;
-      output.lastGrade = encGrade(rr[0]);
+      lastGradeV = encGrade(rr[0]); wGL(output);
       if (rr[1]) {
         recalcBse();
-        pushBest(output);
+        wBrk(output);
       }
     }
   }

--- a/manage.html
+++ b/manage.html
@@ -40,7 +40,7 @@
         <eval input="/Zapp/{zapp_index}/Output/modeSub" outputFormat="script x => sN(x)" default="?" />
       </div>
       <div class="sp-t-l" style="top:calc(59% - 50%e); left:calc(50% - 50%e);">
-        <eval input="/Zapp/{zapp_index}/Output/grade" outputFormat="script x => dG(x)" default="--" />
+        <eval input="/Zapp/{zapp_index}/Output/packedGL" outputFormat="script x => dG(Math.floor(x/952))" default="--" />
       </div>
 
       <div onTap="ev(2)" style="top:57%;left:0;width:70%;height:25%;position:absolute;"></div>
@@ -70,7 +70,7 @@
       <div class="f-ico p-hc" style="top:calc(36% - 50%e);">&#xF266;</div>
 
       <div class="sp-t-l" style="top:calc(48% - 50%e); left:calc(50% - 50%e);">
-        <eval input="/Zapp/{zapp_index}/Output/grade" outputFormat="script x => dG(x)" default="OFF" />
+        <eval input="/Zapp/{zapp_index}/Output/packedGL" outputFormat="script x => dG(Math.floor(x/952))" default="OFF" />
       </div>
 
       <div onTap="ev(2)" style="top:57%;left:0;width:70%;height:25%;position:absolute;"></div>

--- a/manifest.json
+++ b/manifest.json
@@ -35,13 +35,10 @@
   ],
   "out": [
     {
-      "name": "grade"
+      "name": "packedGL"
     },
     {
-      "name": "lastGrade"
-    },
-    {
-      "name": "bestSend"
+      "name": "packedBreak"
     },
     {
       "name": "routePk1",
@@ -66,12 +63,6 @@
     },
     {
       "name": "vState"
-    },
-    {
-      "name": "brkSends"
-    },
-    {
-      "name": "brkRoutes"
     },
     {
       "name": "actT"

--- a/tools/tests/output-pack-equiv.js
+++ b/tools/tests/output-pack-equiv.js
@@ -13,26 +13,35 @@ var check = function(cond, msg) { if (!cond) { console.log("  FAIL  " + msg); fa
 var GRADE_LENS = [41, 24, 29, 11, 14, 30, 11, 12, 1, 1];
 var gradeVals = [];                       // every legal encGrade value
 for (var s = 0; s < 10; s++) for (var i = 0; i < GRADE_LENS[s]; i++) gradeVals.push(s * 100 + i);
-var MAXG = Math.max.apply(null, gradeVals);   // 900
+var MAXG = Math.max.apply(null, gradeVals);   // 900 (highest real grade)
+// The GRADE field can ALSO carry the encGrade(50) "OFF" sentinel (projsetup empty slot → gradeSystem*100+50,
+// max 950 at system 9); the lastGrade field never does (always a real grade or -1). main.js writeG/state-6
+// publish encGrade(50) into gradeV, so the grade field must be exercised over BOTH domains, up to 950.
+var offVals = [];
+for (var s2 = 0; s2 < 10; s2++) offVals.push(s2 * 100 + 50);   // encGrade(50) per grade system
+var gradeFieldVals = gradeVals.concat(offVals);                // grade-field domain (real grades + OFF sentinel)
+var MAXGF = Math.max.apply(null, gradeFieldVals);              // 950
 
 // ---------- packedGL = gradeV*952 + (lastGradeV+1) ----------
 //   grade decode:     Math.floor(x/952)
 //   lastGrade decode: x%952 - 1   (lastGradeV -1 = "none")
+// Round-trips decode the FLOAT32 image (Math.fround) of the composite — exactly what the watch passes to
+// template scripts — so a future >2^24 pack that drops low digits FAILS the round-trip, not just the f32() line.
 console.log("[packedGL] grade + lastGrade");
 var encGL = function(g, lg) { return g * 952 + (lg + 1); };
 var decG  = function(x) { return Math.floor(x / 952); };
 var decLG = function(x) { return x % 952 - 1; };
 var lgVals = [-1].concat(gradeVals);          // lastGrade can be -1 (none)
-for (var a = 0; a < gradeVals.length; a++) {
+for (var a = 0; a < gradeFieldVals.length; a++) {
   for (var b = 0; b < lgVals.length; b++) {
-    var g = gradeVals[a], lg = lgVals[b], x = encGL(g, lg);
+    var g = gradeFieldVals[a], lg = lgVals[b], x = encGL(g, lg), xf = Math.fround(x);
     check(f32(x), "packedGL not float32-exact: g=" + g + " lg=" + lg + " -> " + x);
-    check(decG(x) === g, "grade round-trip g=" + g + " lg=" + lg + " -> " + decG(x));
-    check(decLG(x) === lg, "lastGrade round-trip g=" + g + " lg=" + lg + " -> " + decLG(x));
+    check(decG(xf) === g, "grade round-trip g=" + g + " lg=" + lg + " -> " + decG(xf));
+    check(decLG(xf) === lg, "lastGrade round-trip g=" + g + " lg=" + lg + " -> " + decLG(xf));
   }
 }
-console.log("  max packedGL = " + encGL(MAXG, MAXG) + " (limit 2^24 = 16777216)");
-check(encGL(MAXG, MAXG) < (1 << 24), "packedGL worst case exceeds 2^24");
+console.log("  max packedGL = " + encGL(MAXGF, MAXG) + " (limit 2^24 = 16777216)");
+check(encGL(MAXGF, MAXG) < (1 << 24), "packedGL worst case exceeds 2^24");
 
 // ---------- packedBreak = (bse+1)*4096 + sat(brkSends)*64 + sat(brkRoutes) ----------
 //   bestSend decode:  Math.floor(x/4096) - 1   (bse -1 = none)
@@ -49,11 +58,11 @@ var countVals = [0, 1, 2, 17, 34, 35, 50, 63];   // in-range counts (≤63); 50 
 for (var c = 0; c < bseVals.length; c++) {
   for (var d = 0; d < countVals.length; d++) {
     for (var e = 0; e < countVals.length; e++) {
-      var bse = bseVals[c], bs = countVals[d], br = countVals[e], y = encBrk(bse, bs, br);
+      var bse = bseVals[c], bs = countVals[d], br = countVals[e], y = encBrk(bse, bs, br), yf = Math.fround(y);
       check(f32(y), "packedBreak not float32-exact: bse=" + bse + " bs=" + bs + " br=" + br + " -> " + y);
-      check(decBse(y) === bse, "bestSend round-trip bse=" + bse + " -> " + decBse(y));
-      check(decBS(y) === bs, "brkSends round-trip bs=" + bs + " -> " + decBS(y));
-      check(decBR(y) === br, "brkRoutes round-trip br=" + br + " -> " + decBR(y));
+      check(decBse(yf) === bse, "bestSend round-trip bse=" + bse + " -> " + decBse(yf));
+      check(decBS(yf) === bs, "brkSends round-trip bs=" + bs + " -> " + decBS(yf));
+      check(decBR(yf) === br, "brkRoutes round-trip br=" + br + " -> " + decBR(yf));
     }
   }
 }

--- a/tools/tests/output-pack-equiv.js
+++ b/tools/tests/output-pack-equiv.js
@@ -1,0 +1,68 @@
+// output-pack-equiv.js — proves packedGL / packedBreak encode↔decode round-trips exactly AND that
+// every composite is float32-exact (SuuntoPlus outputs reach template scripts as float32; a value
+// above 2^24 silently loses low digits → wrong grade/count on the watch). See outputs-are-float32.
+//
+// Encoders mirror main.js wGL/wBrk; decoders mirror the active/manage/edit.html outputFormat scripts.
+// If you change a pack, change it in ALL FOUR places and re-run: node tools/tests/output-pack-equiv.js
+
+var f32 = function(x) { return Math.fround(x) === x; };  // exact in float32?
+var fails = 0;
+var check = function(cond, msg) { if (!cond) { console.log("  FAIL  " + msg); fails++; } };
+
+// ---- value ranges (encGrade = gradeSystem*100 + idx; gradeSystem 0..9, idx 0..40) ----
+var GRADE_LENS = [41, 24, 29, 11, 14, 30, 11, 12, 1, 1];
+var gradeVals = [];                       // every legal encGrade value
+for (var s = 0; s < 10; s++) for (var i = 0; i < GRADE_LENS[s]; i++) gradeVals.push(s * 100 + i);
+var MAXG = Math.max.apply(null, gradeVals);   // 900
+
+// ---------- packedGL = gradeV*952 + (lastGradeV+1) ----------
+//   grade decode:     Math.floor(x/952)
+//   lastGrade decode: x%952 - 1   (lastGradeV -1 = "none")
+console.log("[packedGL] grade + lastGrade");
+var encGL = function(g, lg) { return g * 952 + (lg + 1); };
+var decG  = function(x) { return Math.floor(x / 952); };
+var decLG = function(x) { return x % 952 - 1; };
+var lgVals = [-1].concat(gradeVals);          // lastGrade can be -1 (none)
+for (var a = 0; a < gradeVals.length; a++) {
+  for (var b = 0; b < lgVals.length; b++) {
+    var g = gradeVals[a], lg = lgVals[b], x = encGL(g, lg);
+    check(f32(x), "packedGL not float32-exact: g=" + g + " lg=" + lg + " -> " + x);
+    check(decG(x) === g, "grade round-trip g=" + g + " lg=" + lg + " -> " + decG(x));
+    check(decLG(x) === lg, "lastGrade round-trip g=" + g + " lg=" + lg + " -> " + decLG(x));
+  }
+}
+console.log("  max packedGL = " + encGL(MAXG, MAXG) + " (limit 2^24 = 16777216)");
+check(encGL(MAXG, MAXG) < (1 << 24), "packedGL worst case exceeds 2^24");
+
+// ---------- packedBreak = (bse+1)*4096 + sat(brkSends)*64 + sat(brkRoutes) ----------
+//   bestSend decode:  Math.floor(x/4096) - 1   (bse -1 = none)
+//   brkSends decode:  Math.floor(x/64) % 64
+//   brkRoutes decode: x % 64
+console.log("[packedBreak] bestSend + brkSends + brkRoutes (counts saturate at 63)");
+var sat = function(n) { return n > 63 ? 63 : n; };
+var encBrk = function(bse, bs, br) { return (bse + 1) * 4096 + sat(bs) * 64 + sat(br); };
+var decBse = function(x) { return Math.floor(x / 4096) - 1; };
+var decBS  = function(x) { return Math.floor(x / 64) % 64; };
+var decBR  = function(x) { return x % 64; };
+var bseVals = [-1].concat(gradeVals);
+var countVals = [0, 1, 2, 17, 34, 35, 50, 63];   // in-range counts (≤63); 50 = splice cap, 35 = prod ROUTE_LIMIT
+for (var c = 0; c < bseVals.length; c++) {
+  for (var d = 0; d < countVals.length; d++) {
+    for (var e = 0; e < countVals.length; e++) {
+      var bse = bseVals[c], bs = countVals[d], br = countVals[e], y = encBrk(bse, bs, br);
+      check(f32(y), "packedBreak not float32-exact: bse=" + bse + " bs=" + bs + " br=" + br + " -> " + y);
+      check(decBse(y) === bse, "bestSend round-trip bse=" + bse + " -> " + decBse(y));
+      check(decBS(y) === bs, "brkSends round-trip bs=" + bs + " -> " + decBS(y));
+      check(decBR(y) === br, "brkRoutes round-trip br=" + br + " -> " + decBR(y));
+    }
+  }
+}
+// saturation: counts >63 must clamp to 63 (display degrades, composite stays valid) — never corrupt other fields
+check(decBS(encBrk(MAXG, 200, 0)) === 63, "brkSends>63 must saturate to 63");
+check(decBR(encBrk(MAXG, 0, 999)) === 63, "brkRoutes>63 must saturate to 63");
+check(decBse(encBrk(MAXG, 999, 999)) === MAXG, "bestSend must survive saturated counts");
+console.log("  max packedBreak = " + encBrk(MAXG, 63, 63) + " (limit 2^24 = 16777216)");
+check(encBrk(MAXG, 63, 63) < (1 << 24), "packedBreak worst case exceeds 2^24");
+
+console.log(fails === 0 ? "\nALL PASS" : "\n" + fails + " FAILURE(S)");
+process.exit(fails === 0 ? 0 : 1);

--- a/tools/tests/output-pack-equiv.js
+++ b/tools/tests/output-pack-equiv.js
@@ -41,7 +41,7 @@ for (var a = 0; a < gradeFieldVals.length; a++) {
   }
 }
 console.log("  max packedGL = " + encGL(MAXGF, MAXG) + " (limit 2^24 = 16777216)");
-check(encGL(MAXGF, MAXG) < (1 << 24), "packedGL worst case exceeds 2^24");
+check(encGL(MAXGF, MAXG) <= (1 << 24), "packedGL worst case exceeds 2^24");  // 2^24 is the largest float32-exact integer, so the safe limit is <=, not <
 
 // ---------- packedBreak = (bse+1)*4096 + sat(brkSends)*64 + sat(brkRoutes) ----------
 //   bestSend decode:  Math.floor(x/4096) - 1   (bse -1 = none)
@@ -71,7 +71,7 @@ check(decBS(encBrk(MAXG, 200, 0)) === 63, "brkSends>63 must saturate to 63");
 check(decBR(encBrk(MAXG, 0, 999)) === 63, "brkRoutes>63 must saturate to 63");
 check(decBse(encBrk(MAXG, 999, 999)) === MAXG, "bestSend must survive saturated counts");
 console.log("  max packedBreak = " + encBrk(MAXG, 63, 63) + " (limit 2^24 = 16777216)");
-check(encBrk(MAXG, 63, 63) < (1 << 24), "packedBreak worst case exceeds 2^24");
+check(encBrk(MAXG, 63, 63) <= (1 << 24), "packedBreak worst case exceeds 2^24");
 
 console.log(fails === 0 ? "\nALL PASS" : "\n" + fails + " FAILURE(S)");
 process.exit(fails === 0 ? 0 : 1);


### PR DESCRIPTION
## Why
The long-session crash is a **template-swap-on-swipe** transient: swiping between the 3 concurrent apps coexists the outgoing+incoming templates for a UI-memory peak that evicts climb-logger (`relMemCb (exec:ui)` → `RelMem->unload`). The fix lever is shrinking the **mounting** template (`active.html`) footprint — fewer distinct WB path subscriptions = smaller swap peak. (3 apps is mandatory; this stays inside that budget.)

## What
Pack two groups of single-value numeric Outputs into composites, decoded in the templates via `outputFormat` scripts (the bridge de-dupes each to one LID):

| Composite | Encode (main.js) | Replaces |
|-----------|------------------|----------|
| `packedGL` | `grade*952 + (lastGrade+1)` | grade, lastGrade |
| `packedBreak` | `(bestSend+1)*4096 + brkSends*64 + brkRoutes` (base-64, counts saturate at 63) | bestSend, brkSends, brkRoutes |

**active.html distinct zapp-output paths: 13 → 10.** `manage.html` (grade) and `edit.html` (lastGrade) decode `packedGL` too.

`vState` is **deliberately not packed** — it drives `applyVis` in active+manage, and packing it would re-fire `applyVis` on every grade change.

## Correctness
- **float32-safe**: outputs reach template scripts as float32, so each composite stays < 2^24. Max `packedGL` 857,701; max `packedBreak` 3,694,591.
- **whole-publish**: mirror vars hold the latest component so any single-component write republishes the full composite (a partial write would zero the other fields).
- **build-verified completeness**: manifest `out[]` drops the 5 packed-away names → any missed write site fails the build with `Unknown output property`.
- `tools/tests/output-pack-equiv.js` proves both packs round-trip exactly and are float32-exact across the full value ranges.

## Verification
- `build-app.js` → **Build successful**
- deploy `validate.js` → **true**
- output↔manifest lint → clean
- `output-pack-equiv.js` → **ALL PASS**
- `lap-phase-repro.js` → [1]–[7] PASS ([8] is the `ROUTE_LIMIT=999` test-cap artifact; **ALL PASS at 35**)

## Before merge / flash
- ⚠️ `ROUTE_LIMIT` is temporarily **999** (TEMP TEST) to probe the crash ceiling past 35 with the lighter mount — **revert to 35 before merge**.
- ⚠️ `.fea` binaries are **not** in this PR — rebuild via VS Code "Build App" before flashing (CLI build skips deploy-grade validation; `.fea` are never hand-patched).

## Test plan (on watch, 3 apps)
- [ ] Rebuild `.fea` in VS Code, flash
- [ ] READY/CLIMB/BREAK render grade, last-grade, break sends/routes, best-send correctly
- [ ] SETUP + PROJ-SETUP (manage.html) show grade; EDIT (edit.html) shows last-grade
- [ ] Long 3-app session + repeated inter-app swipes — does the eviction ceiling move?

🤖 Generated with [Claude Code](https://claude.com/claude-code)