### PR TITLE
perf: pack 1'/3' peak-HR display into one path (packedPk) — active.html 10→9

### DIFF
--- a/active.html
+++ b/active.html
@@ -159,13 +159,13 @@
           <eval input="/Activity/Lap/-2/HeartRate/Avg" outputFormat="HeartRate_Fourdigits" default="--" /></div>
         <div class="sp-b-s" style="position:absolute;top:0;left:62%;">1'</div>
         <div class="sp-b-s f-num" style="position:absolute;top:0;left:72%;">
-          <eval input="/Zapp/{zapp_index}/Output/routePk1" outputFormat="HeartRate_Fourdigits" default="--" /></div>
+          <eval input="/Zapp/{zapp_index}/Output/packedPk" outputFormat="script x => Math.floor(x/256) > 0 ? ''+Math.floor(x/256) : '--'" default="--" /></div>
         <div class="sp-b-s" style="position:absolute;top:50%;left:16%;">MAX</div>
         <div class="sp-b-s f-num" style="position:absolute;top:50%;left:40%;">
           <eval input="/Activity/Lap/-2/HeartRate/Max" outputFormat="HeartRate_Fourdigits" default="--" /></div>
         <div class="sp-b-s" style="position:absolute;top:50%;left:62%;">3'</div>
         <div class="sp-b-s f-num" style="position:absolute;top:50%;left:72%;">
-          <eval input="/Zapp/{zapp_index}/Output/routePk3" outputFormat="HeartRate_Fourdigits" default="--" /></div>
+          <eval input="/Zapp/{zapp_index}/Output/packedPk" outputFormat="script x => x%256 > 0 ? ''+(x%256) : '--'" default="--" /></div>
       </div>
 
       <div class="p-hc" style="top:57%;width:70%;height:2px;background:rgba(255,255,255,0.3)"></div>

--- a/main.js
+++ b/main.js
@@ -135,6 +135,15 @@ var wBrk = function(o) {
   var bse = bestSendIdx >= 0 ? encGrade(bestSendIdx) : -1;
   o.packedBreak = (bse + 1) * 4096 + Math.max(0, Math.min(63, brkSendsV)) * 64 + Math.max(0, Math.min(63, brkRoutesV));  // symmetric clamp: a negative count would otherwise borrow into the bestSend field, not just its own
 };
+// packedPk = display-only 1'/3' peak-HR pack (BREAK screen), base-256. routePk1/routePk3 STAY as Hz outputs
+// with manifest log:true (FIT logging unchanged — driven by the flag, not a template binding); active.html
+// just binds packedPk instead of the two, dropping 2 mount paths to 1. lastPk1/lastPk3 are Hz (~0.5–4); ×60→bpm,
+// clamped to the 4Hz HR-gate ceiling (240). max 240*256+240 = 61,680 < 2^24. Decode: pk1 floor(x/256), pk3 x%256.
+var wPk = function(o) {
+  var a = lastPk1 > 0 ? Math.min(240, Math.round(lastPk1 * 60)) : 0;
+  var b = lastPk3 > 0 ? Math.min(240, Math.round(lastPk3 * 60)) : 0;
+  o.packedPk = a * 256 + b;
+};
 
 var pushMode = function(o) {
   writeG(o);
@@ -145,8 +154,9 @@ var pushMode = function(o) {
 var setOutputs = function(output) {
   output.vState = state;
   lastGradeV = lastGradeIdx >= 0 ? encGrade(lastGradeIdx) : -1;  // no wGL() here: every state path below republishes packedGL (4/5/6 explicitly, else via writeG) — a wGL now would just be overwritten, an extra publish per tick
-  output.routePk1 = lastPk1;
+  output.routePk1 = lastPk1;  // stays in Hz for FIT logging (HeartRate_Fourdigits format ×60s itself)
   output.routePk3 = lastPk3;
+  wPk(output);                // BREAK-screen bpm display (packedPk); only changes at route finish, framework de-dupes the per-tick rewrite
   output.routeHeight = state === 1 ? Math.max(0, Math.round(curAsc - startAsc)) : sessionH;  // CLIMB shows the CURRENT route's live height only; other screens show the session total
   output.climbMode = climbMode;
   if (state === 5) {

--- a/manifest.json
+++ b/manifest.json
@@ -41,6 +41,9 @@
       "name": "packedBreak"
     },
     {
+      "name": "packedPk"
+    },
+    {
       "name": "routePk1",
       "log": true,
       "shownName": "Peak HR 1min",

--- a/tools/tests/output-pack-equiv.js
+++ b/tools/tests/output-pack-equiv.js
@@ -73,5 +73,28 @@ check(decBse(encBrk(MAXG, 999, 999)) === MAXG, "bestSend must survive saturated 
 console.log("  max packedBreak = " + encBrk(MAXG, 63, 63) + " (limit 2^24 = 16777216)");
 check(encBrk(MAXG, 63, 63) <= (1 << 24), "packedBreak worst case exceeds 2^24");
 
+// ---------- packedPk = pk1bpm*256 + pk3bpm  (display-only 1'/3' peak HR, base-256) ----------
+//   pk1 decode: Math.floor(x/256)   pk3 decode: x%256   (each bpm clamped 0..240 = the 4Hz HR-gate ceiling)
+// main.js encodes from Hz: bpm = hz>0 ? min(240, round(hz*60)) : 0. Test the bpm domain directly (post-Hz→bpm).
+console.log("[packedPk] 1'/3' peak HR (bpm, base-256)");
+var encPk = function(a, b) { return a * 256 + b; };
+var decPk1 = function(x) { return Math.floor(x / 256); };
+var decPk3 = function(x) { return x % 256; };
+var bpmVals = [0, 1, 30, 72, 142, 200, 239, 240];   // 0 = no-peak sentinel; 240 = clamp ceiling
+for (var p = 0; p < bpmVals.length; p++) {
+  for (var q = 0; q < bpmVals.length; q++) {
+    var a = bpmVals[p], b = bpmVals[q], z = encPk(a, b), zf = Math.fround(z);
+    check(f32(z), "packedPk not float32-exact: pk1=" + a + " pk3=" + b + " -> " + z);
+    check(decPk1(zf) === a, "pk1 round-trip pk1=" + a + " pk3=" + b + " -> " + decPk1(zf));
+    check(decPk3(zf) === b, "pk3 round-trip pk1=" + a + " pk3=" + b + " -> " + decPk3(zf));
+  }
+}
+// Hz→bpm clamp: a peak above the 4Hz gate must saturate at 240, not bleed into pk1's field
+var hz2bpm = function(hz) { return hz > 0 ? Math.min(240, Math.round(hz * 60)) : 0; };
+check(hz2bpm(4) === 240 && hz2bpm(5) === 240, "bpm must clamp at 240");
+check(decPk1(encPk(hz2bpm(5), hz2bpm(3))) === 240, "pk3 must not corrupt a clamped pk1");
+console.log("  max packedPk = " + encPk(240, 240) + " (limit 2^24 = 16777216)");
+check(encPk(240, 240) <= (1 << 24), "packedPk worst case exceeds 2^24");
+
 console.log(fails === 0 ? "\nALL PASS" : "\n" + fails + " FAILURE(S)");
 process.exit(fails === 0 ? 0 : 1);


### PR DESCRIPTION
**Stacked on #137** (base = `perf/active-html-output-packing`). Wave-2 footprint lever against the swipe-eviction crash. GitHub will retarget this to `master` once #137 merges.

## What
The two peak-HR fields (`routePk1` 1-min, `routePk3` 3-min) were **2 distinct WB paths** bound on the BREAK screen. This folds their *display* into one new `packedPk`:

- `routePk1`/`routePk3` **stay** as Hz outputs with manifest `log:true` → **FIT logging unchanged** (driven by the flag, not a template binding).
- `active.html` now binds only `packedPk = pk1bpm*256 + pk3bpm` (Hz→bpm, clamped to the 4 Hz HR-gate ceiling 240).

**active.html distinct zapp-output paths: 10 → 9** (combined with #137: 13 → 9).

## Correctness
- float32-safe: max `240*256+240 = 61,680` ≪ 2²⁴.
- `packedPk` changes only at route finish; the framework de-dupes the per-tick rewrite.
- Decode (active.html, expression-form like the other packs): pk1 `Math.floor(x/256)`, pk3 `x%256`; `0 → "--"` (no peak / no HR data).
- `output-pack-equiv.js` extended with a `packedPk` round-trip + Hz→bpm-clamp section.

## Verification
`build-app.js` **Build successful** · deploy `validate.js` **true** · output↔manifest lint **clean** · `output-pack-equiv.js` **ALL PASS** (packedPk max 61,680) · lap-repro [1]–[7] pass ([8] = the `ROUTE_LIMIT=999` test-cap artifact).

## Before merge / flash
- ⚠️ `ROUTE_LIMIT` inherits **999** (TEMP) from #137 — revert to 35 before merge.
- ⚠️ `.fea` not in PR — rebuild in VS Code before flashing.
- Visual check on BREAK: the `1'` / `3'` peak-HR numbers still render bpm (and `--` when a route had no HR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)