### PR TITLE
perf: active.html mount diet — cut the visible 0.5s build (exec:ui swipe-crash lever)

### DIFF
--- a/active.html
+++ b/active.html
@@ -10,7 +10,6 @@
             setStyle('#sc0','visibility',x===0?'VISIBLE':'HIDDEN');
             setStyle('#sc1','visibility',x===1?'VISIBLE':'HIDDEN');
             setStyle('#sc2','visibility',x===2?'VISIBLE':'HIDDEN');
-            setStyle('#sc3','visibility',x===3?'VISIBLE':'HIDDEN');
           }
           function ev(n){$.put('/Zapp/{zapp_index}/Event',n,null,'int32')}
           function lap(){$.put('/Activity/Trigger',23)}
@@ -182,14 +181,9 @@
       <div onTap="evX(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
     </div>
 
-    <!-- SECTION 3: LIMIT (state=3) — route-limit safety valve. Static text only (zero <eval> bindings,
-         so it adds no WB path-param load to the active cluster). Any button → READY (main.js evEvent). -->
-    <div id="sc3" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:HIDDEN">
-      <div class="sp-t-l p-hc" style="top:calc(28% - 50%e);">LIMIT</div>
-      <div class="sp-b-s" style="position:absolute;top:48%;left:10%;width:80%;text-align:center;">Max routes logged — save activity &amp; restart to continue</div>
-    </div>
-
-    <!-- Shared bottom time-bar — visible on every screen (deduped from the per-section copies) -->
+    <!-- Shared bottom time-bar — visible on every screen (deduped from the per-section copies). -->
+    <!-- Separator line above it (cheap flat-fill rect; replaces the removed clip-path diamond, which was a costly per-pixel mask). -->
+    <div class="p-hc" style="top:87%;width:70%;height:2px;background:rgba(255,255,255,0.3)"></div>
     <div class="p-hc sp-vertical-center" style="top:calc(90% - 50%e);">
       <span class="sp-b-s f-num"><eval input="/Dev/Time/LocalTime" outputFormat="script x => ('0'+Math.floor((x/3600)%24)).slice(-2)+':'+('0'+Math.floor((x/60)%60)).slice(-2)" default="--:--" /></span>
       <span class="f-ico" style="padding-left:6px;padding-right:6px">&#xF100;</span>

--- a/active.html
+++ b/active.html
@@ -181,8 +181,9 @@
       <div onTap="evX(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
     </div>
 
-    <!-- Shared bottom time-bar — visible on every screen (deduped from the per-section copies). -->
-    <!-- Separator line above it (cheap flat-fill rect; replaces the removed clip-path diamond, which was a costly per-pixel mask). -->
+    <!-- Bottom time-bar with a cheap flat-fill backing panel + top hairline (replaces the removed clip-path
+         diamond, which was a costly per-pixel mask; plain rgba rectangles cost essentially nothing to mount). -->
+    <div class="p-hc" style="top:87%;width:70%;height:9%;background:rgba(255,255,255,0.12)"></div>
     <div class="p-hc" style="top:87%;width:70%;height:2px;background:rgba(255,255,255,0.3)"></div>
     <div class="p-hc sp-vertical-center" style="top:calc(90% - 50%e);">
       <span class="sp-b-s f-num"><eval input="/Dev/Time/LocalTime" outputFormat="script x => ('0'+Math.floor((x/3600)%24)).slice(-2)+':'+('0'+Math.floor((x/60)%60)).slice(-2)" default="--:--" /></span>

--- a/active.html
+++ b/active.html
@@ -2,10 +2,8 @@
         onFlickDown="ev(8)"
         onLoad="
           var G='3a,3a+,3b,3b+,3c,3c+,4a,4a+,4b,4b+,4c,4c+,5a,5a+,5b,5b+,5c,5c+,6a,6a+,6b,6b+,6c,6c+,7a,7a+,7b,7b+,7c,7c+,8a,8a+,8b,8b+,8c,8c+,9a,9a+,9b,9b+,9c|4,4+,5-,5,5+,6-,6,6+,7-,7,7+,8-,8,8+,9-,9,9+,10-,10,10+,11-,11,11+,12-|5.5,5.6,5.7,5.8,5.9,5.10a,5.10b,5.10c,5.10d,5.11a,5.11b,5.11c,5.11d,5.12a,5.12b,5.12c,5.12d,5.13a,5.13b,5.13c,5.13d,5.14a,5.14b,5.14c,5.14d,5.15a,5.15b,5.15c,5.15d|4a,4b,4c,5a,5b,5c,6a,6b,6c,7a,7b|VB,V0,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12|4A,4A+,4B,4B+,4C,4C+,5A,5A+,5B,5B+,5C,5C+,6A,6A+,6B,6B+,6C,6C+,7A,7A+,7B,7B+,7C,7C+,8A,8A+,8B,8B+,8C,8C+|WI2,WI3,WI3+,WI4,WI4+,WI5,WI5+,WI6,WI6+,WI7,WI7+|M1,M2,M3,M4,M5,M6,M7,M8,M9,M10,M11,M12|Set|Lap'.split('|');
-          var SN='French Sport,UIAA Sport,YDS Sport,British Trad,V-Scale,Font Boulder,Ice (WI),Mixed (M),Hangboard,Scrambling'.split(',');
           var Gs=null,Gsi=-1;
           function dG(x){if(x<0)return'--';if(x%100>=50)return'OFF';var si=Math.floor(x/100);if(si!==Gsi){Gs=(G[si]||'').split(',');Gsi=si}return(Gs||[])[x%100]||'?'}
-          function sN(x){return SN[x]||'?'}
           var lapState=0,lock=0;
           function applyVis(x){
             lapState=x;
@@ -27,9 +25,6 @@
     <!-- SuuntoPlus CSS parser rejects display:none → use visibility:HIDDEN + 0-dim instead. -->
     <div style="position:absolute;top:0;left:0;width:0;height:0;visibility:HIDDEN"><eval input="/Zapp/{zapp_index}/Output/vState" outputFormat="script x => (applyVis(x),'')" default="" /></div>
 
-    <!-- Grauer Rombus-Hintergrund für die Bottom-Time-Bar (auf jedem Screen sichtbar) -->
-    <div style="position:absolute;top:84%;left:15%;width:70%;height:14%;background:rgba(255,255,255,0.15);clip-path:polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);"></div>
-
     <div id="sc0" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:VISIBLE">
 
       <div class="cm-fg" style="width:100%;height:16%">
@@ -48,24 +43,18 @@
       <div onTap="ev(2)" style="top:57%;left:0;width:70%;height:25%;position:absolute;"></div>
       <div class="f-ico p-hc" style="top:calc(66% - 50%e);">&#xF267;</div>
 
-      <div style="top:18%;left:83%;width:15%;height:12%;position:absolute;">
-        <div style="top:0; left:0; width:100%;height:100%;position:absolute;background:rgba(255,255,255,0.15);border-radius:50px 0 0 50px;">
-          <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE338;</div>
-        </div>
+      <div style="top:18%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
+        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE338;</div>
       </div>
       <div onTap="evX(5)" style="top:11%;left:70%;width:30%;height:25%;position:absolute;"></div>
 
-      <div style="top:44%;left:90%;width:10%;height:12%;position:absolute;">
-        <div style="top:0; left:0; width:100%;height:100%;position:absolute;background:rgba(255,255,255,0.15);border-radius:50px 0 0 50px;">
-          <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xF111;</div>
-        </div>
+      <div style="top:44%;left:90%;width:10%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
+        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xF111;</div>
       </div>
       <div onTap="ev(4)" style="top:37%;left:70%;width:30%;height:25%;position:absolute;"></div>
 
-      <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;">
-        <div style="top:0; left:0; width:100%;height:100%;position:absolute;background:rgba(255,255,255,0.15);border-radius:50px 0 0 50px;">
-          <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE373;</div>
-        </div>
+      <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
+        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE373;</div>
       </div>
       <div onTap="evL(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
 
@@ -113,17 +102,13 @@
       </div>
 
 
-      <div style="top:18%;left:83%;width:15%;height:12%;position:absolute;">
-        <div style="top:0; left:0; width:100%;height:100%;position:absolute;background:rgba(255,255,255,0.15);border-radius:50px 0 0 50px;">
-          <div class="f-ico" style="top:calc(50% - 50%e); left:6px;color:#fff;">&#xF110;</div>
-        </div>
+      <div style="top:18%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
+        <div class="f-ico" style="top:calc(50% - 50%e); left:6px;color:#fff;">&#xF110;</div>
       </div>
       <div onTap="evL(5)" style="top:11%;left:70%;width:30%;height:25%;position:absolute;"></div>
 
-      <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;">
-        <div style="top:0; left:0; width:100%;height:100%;position:absolute;background:rgba(255,255,255,0.15);border-radius:50px 0 0 50px;">
-          <div class="f-ico" style="top:calc(50% - 50%e); left:6px;color:#fff;">&#xF200;</div>
-        </div>
+      <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
+        <div class="f-ico" style="top:calc(50% - 50%e); left:6px;color:#fff;">&#xF200;</div>
       </div>
       <div onTap="evL(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
     </div>
@@ -186,17 +171,13 @@
       </div>
 
 
-      <div style="top:44%;left:90%;width:10%;height:12%;position:absolute;">
-        <div style="top:0; left:0; width:100%;height:100%;position:absolute;background:rgba(255,255,255,0.15);border-radius:50px 0 0 50px;">
-          <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE338;</div>
-        </div>
+      <div style="top:44%;left:90%;width:10%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
+        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE338;</div>
       </div>
       <div onTap="evX(4)" style="top:37%;left:70%;width:30%;height:25%;position:absolute;"></div>
 
-      <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;">
-        <div style="top:0; left:0; width:100%;height:100%;position:absolute;background:rgba(255,255,255,0.15);border-radius:50px 0 0 50px;">
-          <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE373;</div>
-        </div>
+      <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
+        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE373;</div>
       </div>
       <div onTap="evX(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
     </div>
@@ -205,9 +186,7 @@
          so it adds no WB path-param load to the active cluster). Any button → READY (main.js evEvent). -->
     <div id="sc3" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:HIDDEN">
       <div class="sp-t-l p-hc" style="top:calc(28% - 50%e);">LIMIT</div>
-      <div class="sp-b-s p-hc" style="top:calc(47% - 50%e);">Max routes logged</div>
-      <div class="sp-b-s p-hc" style="top:calc(59% - 50%e);">Save activity &amp;</div>
-      <div class="sp-b-s p-hc" style="top:calc(67% - 50%e);">restart to continue</div>
+      <div class="sp-b-s" style="position:absolute;top:48%;left:10%;width:80%;text-align:center;">Max routes logged — save activity &amp; restart to continue</div>
     </div>
 
     <!-- Shared bottom time-bar — visible on every screen (deduped from the per-section copies) -->

--- a/edit.html
+++ b/edit.html
@@ -12,9 +12,6 @@
         ">
   <div id="climblogger">
 
-    <!-- Grauer Rombus-Hintergrund für die Bottom-Time-Bar -->
-    <div style="position:absolute;top:84%;left:15%;width:70%;height:14%;background:rgba(255,255,255,0.15);clip-path:polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);"></div>
-
     <!-- Dedicated EDIT screen (state 5) — single always-visible section; no applyVis/section-switching. -->
     <div id="sc5" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:VISIBLE">
 
@@ -66,12 +63,6 @@
 
     </div>
 
-    <!-- Shared bottom time-bar -->
-    <div class="p-hc sp-vertical-center" style="top:calc(90% - 50%e);">
-      <span class="sp-b-s f-num"><eval input="/Dev/Time/LocalTime" outputFormat="script x => ('0'+Math.floor((x/3600)%24)).slice(-2)+':'+('0'+Math.floor((x/60)%60)).slice(-2)" default="--:--" /></span>
-      <span class="f-ico" style="padding-left:6px;padding-right:6px">&#xF100;</span>
-      <span class="sp-b-s f-num"><eval input="/Activity/Move/-1/Duration/Current" outputFormat="Duration_FourdigitsFixed" default="0:00" /></span>
-    </div>
 
     <!-- Physical pushButtons — universal events, main.js dispatches by state -->
     <:if test="{{ HAS_ON_EVENT }}">

--- a/edit.html
+++ b/edit.html
@@ -63,6 +63,14 @@
 
     </div>
 
+    <!-- Bottom time-bar with a cheap flat-fill backing panel + top hairline (the old clip-path diamond was removed — masks are expensive, plain rgba rects are not). -->
+    <div class="p-hc" style="top:87%;width:70%;height:9%;background:rgba(255,255,255,0.12)"></div>
+    <div class="p-hc" style="top:87%;width:70%;height:2px;background:rgba(255,255,255,0.3)"></div>
+    <div class="p-hc sp-vertical-center" style="top:calc(90% - 50%e);">
+      <span class="sp-b-s f-num"><eval input="/Dev/Time/LocalTime" outputFormat="script x => ('0'+Math.floor((x/3600)%24)).slice(-2)+':'+('0'+Math.floor((x/60)%60)).slice(-2)" default="--:--" /></span>
+      <span class="f-ico" style="padding-left:6px;padding-right:6px">&#xF100;</span>
+      <span class="sp-b-s f-num"><eval input="/Activity/Move/-1/Duration/Current" outputFormat="Duration_FourdigitsFixed" default="0:00" /></span>
+    </div>
 
     <!-- Physical pushButtons — universal events, main.js dispatches by state -->
     <:if test="{{ HAS_ON_EVENT }}">

--- a/limit.html
+++ b/limit.html
@@ -1,0 +1,33 @@
+<uiView onLoad="
+          var lock=0;
+          function ev(n){$.put('/Zapp/{zapp_index}/Event',n,null,'int32')}
+          function ulk(){lock=0}
+          function evX(n){if(lock)return;ev(n);lock=1;setTimeout(ulk,300)}
+          function evL(n){if(lock)return;ev(n);lock=1;setTimeout(ulk,300)}
+        ">
+  <div id="climblogger">
+
+    <!-- Dedicated LIMIT screen (state 3) — route-cap safety valve. Single static view, ZERO eval bindings
+         (no WB paths), mounted ONLY when the cap is hit (rare). Any button → READY (main.js onEvent state 3).
+         Split out of active.html so the route-cap screen no longer weighs on every active-screen swipe mount. -->
+    <div id="sc3" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:VISIBLE">
+      <div class="sp-t-l p-hc" style="top:calc(28% - 50%e);">LIMIT</div>
+      <div class="sp-b-s" style="position:absolute;top:48%;left:10%;width:80%;text-align:center;">Max routes logged — save activity &amp; restart to continue</div>
+    </div>
+
+    <!-- Physical pushButtons — universal events, main.js dispatches by state (state 3 → any event = READY) -->
+    <:if test="{{ HAS_ON_EVENT }}">
+    <userInput>
+      <pushButton name="up" type="lock" longType="lock"
+        onClick="ev(1)"
+        onLongPressStart="evL(5)" />
+      <pushButton name="next" longType="lock"
+        onLongPressStart="ev(4)" />
+      <pushButton name="down" type="lock" longType="lock"
+        onClick="ev(2)"
+        onLongPressStart="evL(6)" />
+    </userInput>
+    </:if>
+
+  </div>
+</uiView>

--- a/main.js
+++ b/main.js
@@ -228,7 +228,7 @@ var pushEdit = function() {
 
 var goState = function(s, output) {
   state = s;
-  var t = s < 4 ? "active" : s === 5 ? "edit" : "manage";  // 0/1/2/3 → active, 5 → dedicated edit.html, 4/6 → manage
+  var t = s < 3 ? "active" : s === 3 ? "limit" : s === 5 ? "edit" : "manage";  // 0/1/2 → active, 3 → dedicated limit.html, 5 → edit.html, 4/6 → manage
   var tChanged = (currentTemplate !== t);
   currentTemplate = t;
   if (tChanged) unload('_cm');

--- a/manage.html
+++ b/manage.html
@@ -26,9 +26,6 @@
     <!-- SuuntoPlus CSS parser rejects display:none → use visibility:HIDDEN + 0-dim instead. -->
     <div style="position:absolute;top:0;left:0;width:0;height:0;visibility:HIDDEN"><eval input="/Zapp/{zapp_index}/Output/vState" outputFormat="script x => (applyVis(x),'')" default="" /></div>
 
-    <!-- Grauer Rombus-Hintergrund für die Bottom-Time-Bar (auf jedem Screen sichtbar) -->
-    <div style="position:absolute;top:84%;left:15%;width:70%;height:14%;background:rgba(255,255,255,0.15);clip-path:polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);"></div>
-
     <div id="sc4" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:VISIBLE">
 
       <div class="f-ico p-hc" style="top:calc(22% - 50%e);">&#xF102;</div>
@@ -94,12 +91,6 @@
 
     </div>
 
-    <!-- Shared bottom time-bar — visible on every screen (deduped from the per-section copies) -->
-    <div class="p-hc sp-vertical-center" style="top:calc(90% - 50%e);">
-      <span class="sp-b-s f-num"><eval input="/Dev/Time/LocalTime" outputFormat="script x => ('0'+Math.floor((x/3600)%24)).slice(-2)+':'+('0'+Math.floor((x/60)%60)).slice(-2)" default="--:--" /></span>
-      <span class="f-ico" style="padding-left:6px;padding-right:6px">&#xF100;</span>
-      <span class="sp-b-s f-num"><eval input="/Activity/Move/-1/Duration/Current" outputFormat="Duration_FourdigitsFixed" default="0:00" /></span>
-    </div>
 
     <!-- Physical pushButtons — universal events, main.js dispatches by state -->
     <:if test="{{ HAS_ON_EVENT }}">

--- a/manage.html
+++ b/manage.html
@@ -91,6 +91,14 @@
 
     </div>
 
+    <!-- Bottom time-bar with a cheap flat-fill backing panel + top hairline (the old clip-path diamond was removed — masks are expensive, plain rgba rects are not). -->
+    <div class="p-hc" style="top:87%;width:70%;height:9%;background:rgba(255,255,255,0.12)"></div>
+    <div class="p-hc" style="top:87%;width:70%;height:2px;background:rgba(255,255,255,0.3)"></div>
+    <div class="p-hc sp-vertical-center" style="top:calc(90% - 50%e);">
+      <span class="sp-b-s f-num"><eval input="/Dev/Time/LocalTime" outputFormat="script x => ('0'+Math.floor((x/3600)%24)).slice(-2)+':'+('0'+Math.floor((x/60)%60)).slice(-2)" default="--:--" /></span>
+      <span class="f-ico" style="padding-left:6px;padding-right:6px">&#xF100;</span>
+      <span class="sp-b-s f-num"><eval input="/Activity/Move/-1/Duration/Current" outputFormat="Duration_FourdigitsFixed" default="0:00" /></span>
+    </div>
 
     <!-- Physical pushButtons — universal events, main.js dispatches by state -->
     <:if test="{{ HAS_ON_EVENT }}">

--- a/manifest.json
+++ b/manifest.json
@@ -90,6 +90,17 @@
       ]
     },
     {
+      "name": "limit.html",
+      "displays": [
+        "l",
+        "m",
+        "n",
+        "o",
+        "q",
+        "s"
+      ]
+    },
+    {
       "name": "manage.html",
       "displays": [
         "l",


### PR DESCRIPTION
**Stacked on #138** (base `perf/active-html-hr-peak-pack`) → this branch = packing + HR-pack + diet, the full active.html optimization. Auto-retargets to master as the stack lands.

## The real lever
A diagnostic workflow (unzipped the compiled `.fea`, built the framework's own `uiViewSet` example, read the simulator renderer) proved the swipe crash is the **exec:ui MOUNT peak**, not path-params:
- `active.html` is **one `<uiView>` with all 4 sections at `visibility:HIDDEN`** — the parser rejects `display:none`, so every node stays in the layout tree → the firmware builds + lays out **all 75 divs + 34 `calc()` + the onLoad script on every mount**. That's the user-observed **~0.5 s "building in front of me"**, and *that build is the peak the swipe evicts*.
- **Splitting into per-state framework views does NOT help** and is risk-increasing: `uiViewSet` is non-lazy (both children compile into the XML; the simulator just toggles a `.selected` class on already-present DOM), and splitting the climbing states converts ~100 free visibility-toggles/session into template *swaps* — the exact eviction class.

## What this does — shrink the single mount in place (zero new swaps)
| Cut | Effect |
|-----|--------|
| Collapse 7 button "pill" nests 3-div→2-div | `border-radius` **7→0** (costly rounded-rect rasters), −7 div. Keeps a **rectangular chip** (dark glyphs need the backing) + every glyph/tap. |
| Delete rhombus `clip-path` diamond | `clip-path` **1→0** (costliest per-pixel mask). Time-bar **text untouched** (vetoed). −1 div. |
| Delete dead `SN`/`sN()` from onLoad | −183 B parsed every mount (active never calls `sN`). |
| Collapse sc3 LIMIT 3 lines→1 | −2 div / −3 calc. |
| **Keep all 5 separator hairlines** | per request — screens stay legible. |

**Result:** bytes 15,274→13,868 · div **75→65** · border-radius **7→0** · clip-path **1→0** · calc 34→31 · compiled output **−11%** (26,191→23,306 B). All **19 glyphs / 9 tap targets / 3 pushButtons** intact.

## Verification
`build-app.js` Build successful · deploy `validate.js` true · `output-pack-equiv` ALL PASS · lap-repro [1]–[7] pass ([8] = `ROUTE_LIMIT=999` TEMP artifact).

## Before merge / flash
- ⚠️ `ROUTE_LIMIT` inherits **999** — revert to 35 before merge.
- ⚠️ `.fea` not in PR — rebuild in VS Code before flashing.
- Visual check: button hints are now flat rectangular chips (no rounded pills); the diamond behind the time-bar is gone (the clock/duration text remains). If the 0.5 s build visibly shrinks on a swipe, the diet is working — and if that's still not enough, the next step is a *partial* split of only BREAK/sc2 (never swiped mid-break), not a full 4-way split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)