### PR TITLE
perf: pack route records → 2 float64 arrays (exec:zapp heap — fixes the 30+route freeze-on-end)

### DIFF
--- a/active.html
+++ b/active.html
@@ -9,7 +9,6 @@
             lapState=x;
             setStyle('#sc0','visibility',x===0?'VISIBLE':'HIDDEN');
             setStyle('#sc1','visibility',x===1?'VISIBLE':'HIDDEN');
-            setStyle('#sc2','visibility',x===2?'VISIBLE':'HIDDEN');
           }
           function ev(n){$.put('/Zapp/{zapp_index}/Event',n,null,'int32')}
           function lap(){$.put('/Activity/Trigger',23)}
@@ -112,74 +111,8 @@
       <div onTap="evL(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
     </div>
 
-    <div id="sc2" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:HIDDEN">
-
-      <div class="cm-fg" style="width:100%;height:16%">
-        <div class="sp-t-s p-hc" style="top:calc(50% - 50%e);">
-          <eval input="/Zapp/{zapp_index}/Output/modeSub" outputFormat="script x => x > 0 ? 'ROUTE ' + x : 'PROJECT ' + Math.abs(x)" default="ROUTE" />
-        </div>
-      </div>
-
-      <div class="sp-vertical-center" style="top:calc(27% - 50%e); left:calc(30% - 50%e);">
-        <span class="f-ico" style="padding-right:4px">&#xF144;</span>
-        <span class="sp-b-m"><eval input="/Zapp/{zapp_index}/Output/packedGL" outputFormat="script x => dG(x%952-1)" default="--" /></span>
-      </div>
-
-      <div class="p-hc" style="top:22%;width:2px;height:14%;background:rgba(255,255,255,0.3)"></div>
-
-      <div class="sp-vertical-center" style="top:calc(27% - 50%e); left:calc(70% - 50%e);">
-        <span class="f-ico" style="padding-right:4px">&#xF100;</span>
-        <span class="sp-b-m"><eval input="/Activity/Lap/-2/Duration/Current" outputFormat="Duration_FourdigitsFixed" default="0:00" /></span>
-      </div>
-
-      <div class="p-hc" style="top:36%;width:70%;height:2px;background:rgba(255,255,255,0.3)"></div>
-
-      <div style="position:absolute;top:38%;left:10%;width:80%;height:18%;">
-        <div style="position:absolute;top:25%;left:0;">
-          <span class="f-ico">&#xF101;</span>
-        </div>
-        <div class="sp-b-s" style="position:absolute;top:0;left:16%;">AVG</div>
-        <div class="sp-b-s f-num" style="position:absolute;top:0;left:40%;">
-          <eval input="/Activity/Lap/-2/HeartRate/Avg" outputFormat="HeartRate_Fourdigits" default="--" /></div>
-        <div class="sp-b-s" style="position:absolute;top:0;left:62%;">1'</div>
-        <div class="sp-b-s f-num" style="position:absolute;top:0;left:72%;">
-          <eval input="/Zapp/{zapp_index}/Output/packedPk" outputFormat="script x => Math.floor(x/256) > 0 ? ''+Math.floor(x/256) : '--'" default="--" /></div>
-        <div class="sp-b-s" style="position:absolute;top:50%;left:16%;">MAX</div>
-        <div class="sp-b-s f-num" style="position:absolute;top:50%;left:40%;">
-          <eval input="/Activity/Lap/-2/HeartRate/Max" outputFormat="HeartRate_Fourdigits" default="--" /></div>
-        <div class="sp-b-s" style="position:absolute;top:50%;left:62%;">3'</div>
-        <div class="sp-b-s f-num" style="position:absolute;top:50%;left:72%;">
-          <eval input="/Zapp/{zapp_index}/Output/packedPk" outputFormat="script x => x%256 > 0 ? ''+(x%256) : '--'" default="--" /></div>
-      </div>
-
-      <div class="p-hc" style="top:57%;width:70%;height:2px;background:rgba(255,255,255,0.3)"></div>
-
-      <div class="p-hc sp-vertical-center" style="top:calc(64% - 50%e);">
-        <span class="f-ico" style="padding-right:14px">&#xF107;</span>
-        <span class="f-ico" style="padding-right:6px">&#xF200;</span>
-        <span class="sp-b-s f-num"><eval input="/Zapp/{zapp_index}/Output/packedBreak" outputFormat="script x => ''+(Math.floor(x/64)%64)" default="0" /></span><span class="sp-b-s f-num">/</span><span class="sp-b-s f-num"><eval input="/Zapp/{zapp_index}/Output/packedBreak" outputFormat="script x => ''+(x%64)" default="0" /></span>
-        <span class="f-ico" style="padding-left:16px;padding-right:6px">&#xF118;</span>
-        <span class="sp-b-s"><eval input="/Zapp/{zapp_index}/Output/packedBreak" outputFormat="script x => dG(Math.floor(x/4096)-1)" default="--" /></span>
-        <span class="sp-b-s" style="padding-left:16px">H</span>
-        <span class="sp-b-s f-num" style="padding-left:3px"><eval input="/Zapp/{zapp_index}/Output/routeHeight" outputFormat="script x => (x>=0?'+':'') + x + 'm'" default="--" /></span>
-      </div>
-
-      <div class="p-hc sp-vertical-center" style="top:calc(77% - 50%e);">
-        <span class="f-ico sp-c-red" style="padding-right:4px">&#xF101;</span>
-        <span class="sp-b-s f-num"><eval input="/Activity/Move/-1/Heartrate/Current" outputFormat="HeartRate_Fourdigits" default="--" /></span>
-      </div>
-
-
-      <div style="top:44%;left:90%;width:10%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
-        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE338;</div>
-      </div>
-      <div onTap="evX(4)" style="top:37%;left:70%;width:30%;height:25%;position:absolute;"></div>
-
-      <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
-        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE373;</div>
-      </div>
-      <div onTap="evX(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
-    </div>
+    <!-- BREAK (sc2) split out to its own break.html — active.html now holds only READY(sc0)+CLIMB(sc1),
+         so the tree held during every mount/swap is ~46% smaller. main.js goState routes state 2 → "break". -->
 
     <!-- Bottom time-bar with a cheap flat-fill backing panel + top hairline (replaces the removed clip-path
          diamond, which was a costly per-pixel mask; plain rgba rectangles cost essentially nothing to mount). -->

--- a/break.html
+++ b/break.html
@@ -1,0 +1,112 @@
+<uiView onFlickUp="ev(7)"
+        onFlickDown="ev(8)"
+        onLoad="
+          var G='3a,3a+,3b,3b+,3c,3c+,4a,4a+,4b,4b+,4c,4c+,5a,5a+,5b,5b+,5c,5c+,6a,6a+,6b,6b+,6c,6c+,7a,7a+,7b,7b+,7c,7c+,8a,8a+,8b,8b+,8c,8c+,9a,9a+,9b,9b+,9c|4,4+,5-,5,5+,6-,6,6+,7-,7,7+,8-,8,8+,9-,9,9+,10-,10,10+,11-,11,11+,12-|5.5,5.6,5.7,5.8,5.9,5.10a,5.10b,5.10c,5.10d,5.11a,5.11b,5.11c,5.11d,5.12a,5.12b,5.12c,5.12d,5.13a,5.13b,5.13c,5.13d,5.14a,5.14b,5.14c,5.14d,5.15a,5.15b,5.15c,5.15d|4a,4b,4c,5a,5b,5c,6a,6b,6c,7a,7b|VB,V0,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12|4A,4A+,4B,4B+,4C,4C+,5A,5A+,5B,5B+,5C,5C+,6A,6A+,6B,6B+,6C,6C+,7A,7A+,7B,7B+,7C,7C+,8A,8A+,8B,8B+,8C,8C+|WI2,WI3,WI3+,WI4,WI4+,WI5,WI5+,WI6,WI6+,WI7,WI7+|M1,M2,M3,M4,M5,M6,M7,M8,M9,M10,M11,M12|Set|Lap'.split('|');
+          var Gs=null,Gsi=-1;
+          function dG(x){if(x<0)return'--';if(x%100>=50)return'OFF';var si=Math.floor(x/100);if(si!==Gsi){Gs=(G[si]||'').split(',');Gsi=si}return(Gs||[])[x%100]||'?'}
+          var lapState=2,lock=0;
+          function ev(n){$.put('/Zapp/{zapp_index}/Event',n,null,'int32')}
+          function lap(){$.put('/Activity/Trigger',23)}
+          function ulk(){lock=0}
+          function evX(n){if(lock)return;ev(n);lock=1;setTimeout(ulk,300)}
+          function evL(n){if(lock)return;var s=lapState;if((n===6&&s===0)||s===1)lap();ev(n);lock=1;setTimeout(ulk,300)}
+        ">
+  <div id="climblogger">
+
+    <!-- Dedicated BREAK screen (state 2) — split out of active.html so the READY/CLIMB mount (what you
+         swipe to, and the tree held during every swap) drops ~46%. CLIMB↔BREAK become small template
+         swaps; you never swipe mid-break. lapState hardcoded 2 (evL never laps in BREAK). -->
+    <div id="sc2" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:VISIBLE">
+
+      <div class="cm-fg" style="width:100%;height:16%">
+        <div class="sp-t-s p-hc" style="top:calc(50% - 50%e);">
+          <eval input="/Zapp/{zapp_index}/Output/modeSub" outputFormat="script x => x > 0 ? 'ROUTE ' + x : 'PROJECT ' + Math.abs(x)" default="ROUTE" />
+        </div>
+      </div>
+
+      <div class="sp-vertical-center" style="top:calc(27% - 50%e); left:calc(30% - 50%e);">
+        <span class="f-ico" style="padding-right:4px">&#xF144;</span>
+        <span class="sp-b-m"><eval input="/Zapp/{zapp_index}/Output/packedGL" outputFormat="script x => dG(x%952-1)" default="--" /></span>
+      </div>
+
+      <div class="p-hc" style="top:22%;width:2px;height:14%;background:rgba(255,255,255,0.3)"></div>
+
+      <div class="sp-vertical-center" style="top:calc(27% - 50%e); left:calc(70% - 50%e);">
+        <span class="f-ico" style="padding-right:4px">&#xF100;</span>
+        <span class="sp-b-m"><eval input="/Activity/Lap/-2/Duration/Current" outputFormat="Duration_FourdigitsFixed" default="0:00" /></span>
+      </div>
+
+      <div class="p-hc" style="top:36%;width:70%;height:2px;background:rgba(255,255,255,0.3)"></div>
+
+      <div style="position:absolute;top:38%;left:10%;width:80%;height:18%;">
+        <div style="position:absolute;top:25%;left:0;">
+          <span class="f-ico">&#xF101;</span>
+        </div>
+        <div class="sp-b-s" style="position:absolute;top:0;left:16%;">AVG</div>
+        <div class="sp-b-s f-num" style="position:absolute;top:0;left:40%;">
+          <eval input="/Activity/Lap/-2/HeartRate/Avg" outputFormat="HeartRate_Fourdigits" default="--" /></div>
+        <div class="sp-b-s" style="position:absolute;top:0;left:62%;">1'</div>
+        <div class="sp-b-s f-num" style="position:absolute;top:0;left:72%;">
+          <eval input="/Zapp/{zapp_index}/Output/packedPk" outputFormat="script x => Math.floor(x/256) > 0 ? ''+Math.floor(x/256) : '--'" default="--" /></div>
+        <div class="sp-b-s" style="position:absolute;top:50%;left:16%;">MAX</div>
+        <div class="sp-b-s f-num" style="position:absolute;top:50%;left:40%;">
+          <eval input="/Activity/Lap/-2/HeartRate/Max" outputFormat="HeartRate_Fourdigits" default="--" /></div>
+        <div class="sp-b-s" style="position:absolute;top:50%;left:62%;">3'</div>
+        <div class="sp-b-s f-num" style="position:absolute;top:50%;left:72%;">
+          <eval input="/Zapp/{zapp_index}/Output/packedPk" outputFormat="script x => x%256 > 0 ? ''+(x%256) : '--'" default="--" /></div>
+      </div>
+
+      <div class="p-hc" style="top:57%;width:70%;height:2px;background:rgba(255,255,255,0.3)"></div>
+
+      <div class="p-hc sp-vertical-center" style="top:calc(64% - 50%e);">
+        <span class="f-ico" style="padding-right:14px">&#xF107;</span>
+        <span class="f-ico" style="padding-right:6px">&#xF200;</span>
+        <span class="sp-b-s f-num"><eval input="/Zapp/{zapp_index}/Output/packedBreak" outputFormat="script x => ''+(Math.floor(x/64)%64)" default="0" /></span><span class="sp-b-s f-num">/</span><span class="sp-b-s f-num"><eval input="/Zapp/{zapp_index}/Output/packedBreak" outputFormat="script x => ''+(x%64)" default="0" /></span>
+        <span class="f-ico" style="padding-left:16px;padding-right:6px">&#xF118;</span>
+        <span class="sp-b-s"><eval input="/Zapp/{zapp_index}/Output/packedBreak" outputFormat="script x => dG(Math.floor(x/4096)-1)" default="--" /></span>
+        <span class="sp-b-s" style="padding-left:16px">H</span>
+        <span class="sp-b-s f-num" style="padding-left:3px"><eval input="/Zapp/{zapp_index}/Output/routeHeight" outputFormat="script x => (x>=0?'+':'') + x + 'm'" default="--" /></span>
+      </div>
+
+      <div class="p-hc sp-vertical-center" style="top:calc(77% - 50%e);">
+        <span class="f-ico sp-c-red" style="padding-right:4px">&#xF101;</span>
+        <span class="sp-b-s f-num"><eval input="/Activity/Move/-1/Heartrate/Current" outputFormat="HeartRate_Fourdigits" default="--" /></span>
+      </div>
+
+
+      <div style="top:44%;left:90%;width:10%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
+        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE338;</div>
+      </div>
+      <div onTap="evX(4)" style="top:37%;left:70%;width:30%;height:25%;position:absolute;"></div>
+
+      <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
+        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE373;</div>
+      </div>
+      <div onTap="evX(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
+    </div>
+
+    <!-- Bottom time-bar with a cheap flat-fill backing panel + top hairline -->
+    <div class="p-hc" style="top:87%;width:70%;height:9%;background:rgba(255,255,255,0.12)"></div>
+    <div class="p-hc" style="top:87%;width:70%;height:2px;background:rgba(255,255,255,0.3)"></div>
+    <div class="p-hc sp-vertical-center" style="top:calc(90% - 50%e);">
+      <span class="sp-b-s f-num"><eval input="/Dev/Time/LocalTime" outputFormat="script x => ('0'+Math.floor((x/3600)%24)).slice(-2)+':'+('0'+Math.floor((x/60)%60)).slice(-2)" default="--:--" /></span>
+      <span class="f-ico" style="padding-left:6px;padding-right:6px">&#xF100;</span>
+      <span class="sp-b-s f-num"><eval input="/Activity/Move/-1/Duration/Current" outputFormat="Duration_FourdigitsFixed" default="0:00" /></span>
+    </div>
+
+    <!-- Physical pushButtons — universal events, main.js dispatches by state -->
+    <:if test="{{ HAS_ON_EVENT }}">
+    <userInput>
+      <pushButton name="up" type="lock" longType="lock"
+        onClick="ev(1)"
+        onLongPressStart="evL(5)" />
+      <pushButton name="next" longType="lock"
+        onLongPressStart="ev(4)" />
+      <pushButton name="down" type="lock" longType="lock"
+        onClick="ev(2)"
+        onLongPressStart="evL(6)" />
+    </userInput>
+    </:if>
+
+  </div>
+</uiView>

--- a/edit.html
+++ b/edit.html
@@ -39,25 +39,19 @@
         <span id="ed-sendLabel" class="sp-b-m">FAIL</span>
       </div>
 
-      <div style="top:18%;left:83%;width:15%;height:12%;position:absolute;">
-        <div style="top:0; left:0; width:100%;height:100%;position:absolute;background:rgba(255,255,255,0.15);border-radius:50px 0 0 50px;">
-          <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE365;</div>
-        </div>
+      <div style="top:18%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
+        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE365;</div>
       </div>
       <div onTap="evX(5)" style="top:11%;left:70%;width:30%;height:25%;position:absolute;"></div>
 
-      <div style="top:44%;left:90%;width:10%;height:12%;position:absolute;">
-        <div style="top:0; left:0; width:100%;height:100%;position:absolute;background:rgba(255,255,255,0.15);border-radius:50px 0 0 50px;">
-          <div id="ed-pillIcon" class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xF107;</div>
-          <div id="ed-pillDel" class="sp-b-s cm-bgc" style="top:calc(50% - 50%e); left:2px;visibility:HIDDEN">DEL</div>
-        </div>
+      <div style="top:44%;left:90%;width:10%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
+        <div id="ed-pillIcon" class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xF107;</div>
+        <div id="ed-pillDel" class="sp-b-s cm-bgc" style="top:calc(50% - 50%e); left:2px;visibility:HIDDEN">DEL</div>
       </div>
       <div onTap="ev(4)" style="top:37%;left:70%;width:30%;height:25%;position:absolute;"></div>
 
-      <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;">
-        <div style="top:0; left:0; width:100%;height:100%;position:absolute;background:rgba(255,255,255,0.15);border-radius:50px 0 0 50px;">
-          <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE373;</div>
-        </div>
+      <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
+        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE373;</div>
       </div>
       <div onTap="ev(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
 

--- a/ext14.js
+++ b/ext14.js
@@ -5,6 +5,5 @@ if(pgi[i]===-1){
 var slot=i+1;
 pgi[i]=lgi;
 ps[gs+"_"+slot]={attempts:1,sends:lres?1:0,bestTime:lres&&ld>0?ld:0,g:lgi,firstSes:ses};
-if(routes.length>0)routes[routes.length-1][2]=slot;
 return[lgi,slot]}}
 return null}

--- a/ext19.js
+++ b/ext19.js
@@ -1,12 +1,12 @@
-function(routes,gs){
-var n=routes?routes.length:-1;
-if(!routes||n===0)return[{id:'sr',name:'Sends / Routes',format:'Count_Fourdigits',value:0,postfix:'/ 0'}];
+function(rA,rB,gs){
+var n=rA?rA.length:-1;
+if(!rA||n===0)return[{id:'sr',name:'Sends / Routes',format:'Count_Fourdigits',value:0,postfix:'/ 0'}];
 var s=0,ht=0,sp=-1,spC=0,dur=0,hrSum=0,hrCnt=0;
-for(var i=0;i<n;i++){var rr=routes[i],enc=gs*100+rr[0];
-if(rr[1]){s++;if(enc>sp){sp=enc;spC=1}else if(enc===sp)spC++}
-if(rr[3]>0)ht+=rr[3];
-if(rr[4]>0)dur+=rr[4];
-if(rr[5]>0){hrSum+=rr[5];hrCnt++}}
+for(var i=0;i<n;i++){var a=rA[i],b=rB[i],grade=Math.floor(a/1e6),send=Math.floor(a/1e5)%10,height=a%1e4,d=Math.floor(b/1000),hr=b%1000,enc=gs*100+grade;
+if(send){s++;if(enc>sp){sp=enc;spC=1}else if(enc===sp)spC++}
+if(height>0)ht+=height;
+if(d>0)dur+=d;
+if(hr>0){hrSum+=hr;hrCnt++}}
 var htR=Math.round(ht);
 var out=[{id:'sr',name:'Sends / Routes',format:'Count_Fourdigits',value:s,postfix:'/ '+n}];
 if(sp>=0)out.push({id:'b',name:'Highest Send',format:'Count_Fourdigits',value:spC,postfix:'* ',g:sp});

--- a/main.js
+++ b/main.js
@@ -245,7 +245,7 @@ var pushEdit = function() {
 
 var goState = function(s, output) {
   state = s;
-  var t = s < 3 ? "active" : s === 3 ? "limit" : s === 5 ? "edit" : "manage";  // 0/1/2 → active, 3 → dedicated limit.html, 5 → edit.html, 4/6 → manage
+  var t = s < 2 ? "active" : s === 2 ? "break" : s === 3 ? "limit" : s === 5 ? "edit" : "manage";  // 0/1 → active (READY/CLIMB), 2 → break.html, 3 → limit.html, 5 → edit.html, 4/6 → manage
   var tChanged = (currentTemplate !== t);
   currentTemplate = t;
   if (tChanged) unload('_cm');

--- a/main.js
+++ b/main.js
@@ -3,8 +3,25 @@ var state = 4;
 
 var currentGrade = 18;
 var routeNumber = 1;
-var routes = [];
-var routesEvicted = 0;   // set to 1 once commitDirty splices routes[] past 50 (only reachable when ROUTE_LIMIT > the splice cap, e.g. the 999 TEMP build) — routes[] is then incomplete, so rescanBest must not recompute a slot best from it
+// Packed route records (was routes[] of [grade,send,cm,height,dur,hrAvg]): 2 parallel float64 arrays,
+// ~16B/route vs ~120B for the boxed JS array — the exec:zapp HEAP lever (route-record growth is what
+// fills the JS heap at 30+ routes → JSalloc storm / freeze-on-end). App-internal only: these never cross
+// the float32 output transit, so float64's exact-integer range (2^53) holds the packs. hrAvg stays in Hz
+// (unrounded): ext19 renders it via HeartRate_Fourdigits (×60), so packing bpm would show HR 60× wrong.
+//   A = grade*1e6 + send*1e5 + cm*1e4 + height(0..9999)   B = dur(0..86399)*1000 + hrAvgHz(0..~4, fractional kept)
+var routesA = [], routesB = [];
+var routesEvicted = 0;   // set to 1 once commitDirty splices routesA/routesB past the 50 cap (only reachable when ROUTE_LIMIT > 50, e.g. the 999 TEMP build) — the arrays are then incomplete, so rescanBest must not recompute a slot best from them
+var packA = function(g, s, c, h) { return g * 1e6 + s * 1e5 + c * 1e4 + Math.min(9999, Math.max(0, Math.round(h))); };
+var packB = function(d, hr) { return Math.min(86399, Math.max(0, Math.round(d))) * 1000 + (hr > 0 ? hr : 0); };
+var rGrade = function(i) { return Math.floor(routesA[i] / 1e6); };
+var rSend  = function(i) { return Math.floor(routesA[i] / 1e5) % 10; };
+var rCm    = function(i) { return Math.floor(routesA[i] / 1e4) % 10; };
+var rHt    = function(i) { return routesA[i] % 1e4; };
+var rDur   = function(i) { return Math.floor(routesB[i] / 1000); };
+var rHr    = function(i) { return routesB[i] % 1000; };
+var wGrade = function(i, v) { routesA[i] = packA(v, rSend(i), rCm(i), rHt(i)); };
+var wSend  = function(i, v) { routesA[i] = packA(rGrade(i), v, rCm(i), rHt(i)); };
+var wCm    = function(i, v) { routesA[i] = packA(rGrade(i), rSend(i), v, rHt(i)); };
 var sendsCount = 0;
 var lastResult = 0;
 
@@ -160,10 +177,10 @@ var setOutputs = function(output) {
   output.routeHeight = state === 1 ? Math.max(0, Math.round(curAsc - startAsc)) : sessionH;  // CLIMB shows the CURRENT route's live height only; other screens show the session total
   output.climbMode = climbMode;
   if (state === 5) {
-    var rr = routes[editIdx];
-    lastGradeV = rr ? encGrade(rr[0]) : -1; wGL(output);
-    output.modeSub = routes.length;
-    output.climbMode = rr ? (rr[2] || 0) : 0;
+    var has = editIdx < routesA.length;
+    lastGradeV = has ? encGrade(rGrade(editIdx)) : -1; wGL(output);
+    output.modeSub = routesA.length;
+    output.climbMode = has ? (rCm(editIdx) || 0) : 0;
     return;
   } else if (state === 6) {
     gradeV = projGradeIdx[pStep] >= 0 ? encGrade(projGradeIdx[pStep]) : encGrade(50);
@@ -205,13 +222,13 @@ var writeActStats = function(output) {
 
 // T6: edit screen route counter + send-state icons/label pushed event-driven via setText.
 var pushEdit = function() {
-  var n = routes.length, rr = routes[editIdx];
-  var ev = editDelMark ? 2 : (rr ? rr[1] : 0);
+  var n = routesA.length, has = editIdx < n;
+  var ev = editDelMark ? 2 : (has ? rSend(editIdx) : 0);
   setText("#ed-routeNum", "" + (n > 0 ? editIdx + 1 : 0));
   // A-slimming: "/N" total + grade arrows moved off <eval> bindings (edit.html keeps only the lastGrade eval).
   setText("#ed-total", "" + n);
-  // Grade up/down arrows: hidden on project routes (rr[2]>0) — mirrors the old climbMode <eval>s and the evEdit eid 1/2 !rr[2] guard.
-  var arr = (rr && rr[2] > 0) ? "HIDDEN" : "VISIBLE";
+  // Grade up/down arrows: hidden on project routes (cm>0) — mirrors the old climbMode <eval>s and the evEdit eid 1/2 !cm guard.
+  var arr = (has && rCm(editIdx) > 0) ? "HIDDEN" : "VISIBLE";
   setStyle("#ed-arrUp", "visibility", arr);
   setStyle("#ed-arrDn", "visibility", arr);
   setText("#ed-sendIcon", ev === 2 ? "" : ev === 1 ? String.fromCharCode(0xF200) : String.fromCharCode(0xF110));
@@ -276,9 +293,10 @@ var toggleMode = function() {
 };
 
 var saveAsProject = function(output) {
-  var r = loadExt(14)(climbMode, gradeSystem, lastGradeIdx, lastResult, lastDuration, projGradeIdx, projStats, routes, allTimeStats.sessions);
+  var r = loadExt(14)(climbMode, gradeSystem, lastGradeIdx, lastResult, lastDuration, projGradeIdx, projStats, routesA, allTimeStats.sessions);
   if (r) {
     currentGrade = r[0]; climbMode = r[1];
+    if (routesA.length > 0) wCm(routesA.length - 1, r[1]);  // tag the just-finished route with its new project slot (ext14's internal routes[len-1][2]=slot moved out for packing)
     allProjects[gradeSystem] = projGradeIdx.slice();  // in-memory update only
     wsDirty = 1;  // ext14 mutated projGradeIdx — persist watchSetup at onExerciseEnd
     // projStats mutated by ext14 → already covered by unconditional climbProjStats write at onExerciseEnd
@@ -288,9 +306,8 @@ var saveAsProject = function(output) {
 
 var recalcBse = function() {
   bestSendIdx = -1;
-  for (var i = 0; i < routes.length; i++) {
-    var rr = routes[i];
-    if (rr[1] && rr[0] > bestSendIdx) bestSendIdx = rr[0];
+  for (var i = 0; i < routesA.length; i++) {
+    if (rSend(i) && rGrade(i) > bestSendIdx) bestSendIdx = rGrade(i);
   }
 };
 
@@ -305,9 +322,8 @@ var rescanBest = function(cm) {
   var p = projStats[gradeSystem + "_" + cm];
   if (!p || p.firstSes !== allTimeStats.sessions) return;
   var best = 0;
-  for (var i = 0; i < routes.length; i++) {
-    var rr = routes[i];
-    if (rr[1] && rr[2] === cm && rr[4] > 0 && (best === 0 || rr[4] < best)) best = rr[4];
+  for (var i = 0; i < routesA.length; i++) {
+    if (rSend(i) && rCm(i) === cm && rDur(i) > 0 && (best === 0 || rDur(i) < best)) best = rDur(i);
   }
   p.bestTime = best;
   projStatsDirty = 1;
@@ -325,8 +341,10 @@ var commitDirty = function(input) {
       frSend, lastClimbMode, bestSendIdx, projStats, allTimeStats, lastHeight);  // lastClimbMode (slot at finish), NOT live climbMode — cycleSlot in BREAK must not re-tag this route
     bestSendIdx = r[0];
     if (r[2]) {
-      routes.push(r[2]);
-      if (routes.length > 50) { routes.splice(0, routes.length - 50); routesEvicted = 1; }  // routes[] now incomplete → rescanBest must not trust it (see its guard)
+      var rec = r[2];  // [grade, send, cm, height, dur, hrAvg] transient from ext10 (f10) — packed here, not stored boxed
+      routesA.push(packA(rec[0], rec[1], rec[2], rec[3]));
+      routesB.push(packB(rec[4], rec[5]));
+      if (routesA.length > 50) { routesA.splice(0, routesA.length - 50); routesB.splice(0, routesB.length - 50); routesEvicted = 1; }  // arrays now incomplete → rescanBest must not trust them (see its guard)
       allTimeStats.totalRoutes++;
       if (frSend) allTimeStats.totalSends++;
       recPct();
@@ -342,7 +360,7 @@ var startClimb = function(output) {
   // Route-limit safety valve: at ROUTE_LIMIT logged routes, refuse new climbs and show the LIMIT
   // screen (state 3). Forces a save+restart, which resets per-session heap/subscriptions — the thing
   // that let multi-app sessions survive across restarts (the shared 3-app path-param ceiling).
-  if (routes.length >= ROUTE_LIMIT) { goState(3, output); return; }
+  if (routesA.length >= ROUTE_LIMIT) { goState(3, output); return; }
   // #103: in project mode, block the climb start until the active project slot has a grade.
   // toggleMode/projSetup stay reachable so the project CAN be configured.
   if (climbMode > 0 && projGradeIdx[climbMode - 1] < 0) return;
@@ -370,7 +388,7 @@ var evReady = function(output, eid, dy) {
     if (modeChanged) writeActStats(output);  // refresh project stats line for the new slot
   } else if (eid === 5) {
     if (climbMode === 0) {
-      editIdx = routes.length > 0 ? routes.length - 1 : 0;
+      editIdx = routesA.length > 0 ? routesA.length - 1 : 0;
       goState(5, output);
     } else {
       pStep = 0;
@@ -406,7 +424,7 @@ var evBreak = function(output, eid, dy) {
       // !frDirty: while the just-finished route is still pending (not yet pushed by commitDirty),
       // routes[len-1] is the PREVIOUS route — editing it here corrupts it. The pending route picks
       // up the corrected lastGradeIdx on push, so skip the array write until it's committed.
-      if (routes.length > 0 && !frDirty) routes[routes.length - 1][0] = lastGradeIdx;
+      if (routesA.length > 0 && !frDirty) wGrade(routesA.length - 1, lastGradeIdx);
       lastGradeV = encGrade(lastGradeIdx);
       writeG(output);  // publishes packedGL with the new gradeV + lastGradeV
       if (lastResult) {
@@ -452,40 +470,39 @@ var evProjSetup = function(output, eid, dy) {
 };
 
 var evEdit = function(output, eid) {
-  var n = routes.length;
+  var n = routesA.length;
   if (eid === 5 || eid === 6) {
     if (editDelMark) {
-      var dr = routes[editIdx];
-      if (dr) {
+      if (editIdx < routesA.length) {
+        var dSend = rSend(editIdx), dCm = rCm(editIdx), dHt = rHt(editIdx);
         allTimeStats.totalRoutes--;
-        if (dr[1]) { allTimeStats.totalSends--; if (sendsCount > 0) sendsCount--; }
+        if (dSend) { allTimeStats.totalSends--; if (sendsCount > 0) sendsCount--; }
         recPct();
-        if (dr[2] > 0) {
-          var dk = gradeSystem + "_" + dr[2], dp = projStats[dk];
+        if (dCm > 0) {
+          var dk = gradeSystem + "_" + dCm, dp = projStats[dk];
           if (dp) {
             if (dp.attempts > 0) dp.attempts--;
-            if (dr[1] && dp.sends > 0) dp.sends--;
+            if (dSend && dp.sends > 0) dp.sends--;
             if (dp.attempts <= 0) delete projStats[dk]; else projStats[dk] = dp;
             projStatsDirty = 1;
           }
         }
-        if (dr[3] > 0) sessionH = Math.max(0, sessionH - dr[3]);
-        routes.splice(editIdx, 1);
+        if (dHt > 0) sessionH = Math.max(0, sessionH - dHt);
+        routesA.splice(editIdx, 1); routesB.splice(editIdx, 1);
         recalcBse();
-        if (dr[2] > 0) rescanBest(dr[2]);  // deleted route may have held the slot's best — recompute from what's left
+        if (dCm > 0) rescanBest(dCm);  // deleted route may have held the slot's best — recompute from what's left
         if (routeNumber > 1) routeNumber--;
-        n = routes.length;
+        n = routesA.length;
         if (editIdx >= n && n > 0) editIdx = n - 1;
       }
       editDelMark = 0;
     }
     if (eid === 6 && n > 0) {
       editIdx = (editIdx - 1 + n) % n;
-      var pr = routes[editIdx];
-      if (pr) {
-        lastGradeV = encGrade(pr[0]); wGL(output);
+      if (editIdx < routesA.length) {
+        lastGradeV = encGrade(rGrade(editIdx)); wGL(output);
         output.modeSub = n;
-        output.climbMode = pr[2] || 0;
+        output.climbMode = rCm(editIdx) || 0;
       }
       pushEdit();  // T6: routeNum + editSend display moved to setText
     } else {
@@ -495,25 +512,26 @@ var evEdit = function(output, eid) {
   }
   if (n === 0) return;
   if (eid === 4) {
-    var r = routes[editIdx];
-    if (r) {
+    if (editIdx < routesA.length) {
       if (editDelMark) {
         editDelMark = 0;
-        r[1] = 1;
+        wSend(editIdx, 1);
         sendsCount++;
         allTimeStats.totalSends++;
-        if (r[2] > 0) {
-          var k = gradeSystem + "_" + r[2], p = projStats[k];
-          if (p) { p.sends++; if (r[4] > 0 && (p.bestTime === 0 || r[4] < p.bestTime)) p.bestTime = r[4]; projStatsDirty = 1; }
+        var cm4 = rCm(editIdx);
+        if (cm4 > 0) {
+          var k = gradeSystem + "_" + cm4, p = projStats[k];
+          if (p) { p.sends++; var d4 = rDur(editIdx); if (d4 > 0 && (p.bestTime === 0 || d4 < p.bestTime)) p.bestTime = d4; projStatsDirty = 1; }
         }
-      } else if (r[1]) {
-        r[1] = 0;
+      } else if (rSend(editIdx)) {
+        wSend(editIdx, 0);
         if (sendsCount > 0) sendsCount--;
         allTimeStats.totalSends--;
-        if (r[2] > 0) {
-          var k2 = gradeSystem + "_" + r[2], p2 = projStats[k2];
+        var cm5 = rCm(editIdx);
+        if (cm5 > 0) {
+          var k2 = gradeSystem + "_" + cm5, p2 = projStats[k2];
           if (p2 && p2.sends > 0) { p2.sends--; projStatsDirty = 1; }
-          rescanBest(r[2]);  // un-sent route may have held the slot's best — recompute (r[1] is now 0, so it's excluded)
+          rescanBest(cm5);  // un-sent route may have held the slot's best — recompute (send is now 0, so it's excluded)
         }
       } else {
         editDelMark = 1;
@@ -524,12 +542,12 @@ var evEdit = function(output, eid) {
       pushEdit();  // T6: editSend icons/label moved to setText
     }
   } else if (eid === 1 || eid === 2) {
-    var rr = routes[editIdx];
-    if (rr && !rr[2]) {
+    if (editIdx < routesA.length && !rCm(editIdx)) {
       var dy5 = eid === 1 ? 1 : -1, L = GRADE_LENS[gradeSystem];
-      rr[0] = ((rr[0] + dy5) % L + L) % L;
-      lastGradeV = encGrade(rr[0]); wGL(output);
-      if (rr[1]) {
+      var ng = ((rGrade(editIdx) + dy5) % L + L) % L;
+      wGrade(editIdx, ng);
+      lastGradeV = encGrade(ng); wGL(output);
+      if (rSend(editIdx)) {
         recalcBse();
         wBrk(output);
       }
@@ -603,7 +621,7 @@ function onExerciseEnd(input, _output) {
   allTimeStats.totalHeight = (allTimeStats.totalHeight || 0) + sessionH;
   try { writeStats(); } catch (e) {}
   // Summary cache here, not in ext19 — LS in ex-saving window drops summary.
-  try { if (routes.length > 0) LS.setObject("lastSummary", loadExt(19)(routes, gradeSystem)); } catch (e) {}
+  try { if (routesA.length > 0) LS.setObject("lastSummary", loadExt(19)(routesA, routesB, gradeSystem)); } catch (e) {}
 }
 
 function onEvent(_input, output, eventId) {

--- a/manage.html
+++ b/manage.html
@@ -44,10 +44,8 @@
       <div class="f-ico p-hc" style="top:calc(74% - 50%e);">&#xF267;</div>
 
       <!-- Bottom pill (save) — DOWN-long = save&exit on setup -->
-      <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;">
-        <div style="top:0; left:0; width:100%;height:100%;position:absolute;background:rgba(255,255,255,0.15);border-radius:50px 0 0 50px;">
-          <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE373;</div>
-        </div>
+      <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
+        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE373;</div>
       </div>
       <div onTap="evX(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
 
@@ -74,18 +72,14 @@
       <div class="f-ico p-hc" style="top:calc(66% - 50%e);">&#xF267;</div>
 
       <!-- Top pill (save & back to ready) — UP-long = save & back -->
-      <div style="top:18%;left:83%;width:15%;height:12%;position:absolute;">
-        <div style="top:0; left:0; width:100%;height:100%;position:absolute;background:rgba(255,255,255,0.15);border-radius:50px 0 0 50px;">
-          <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE365;</div>
-        </div>
+      <div style="top:18%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
+        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE365;</div>
       </div>
       <div onTap="evX(5)" style="top:11%;left:70%;width:30%;height:25%;position:absolute;"></div>
 
       <!-- Bottom pill (save & next slot) — DOWN-long = save & weiter -->
-      <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;">
-        <div style="top:0; left:0; width:100%;height:100%;position:absolute;background:rgba(255,255,255,0.15);border-radius:50px 0 0 50px;">
-          <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE373;</div>
-        </div>
+      <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
+        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE373;</div>
       </div>
       <div onTap="ev(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
 

--- a/manifest.json
+++ b/manifest.json
@@ -90,6 +90,17 @@
       ]
     },
     {
+      "name": "break.html",
+      "displays": [
+        "l",
+        "m",
+        "n",
+        "o",
+        "q",
+        "s"
+      ]
+    },
+    {
       "name": "limit.html",
       "displays": [
         "l",

--- a/tools/tests/lap-phase-repro.js
+++ b/tools/tests/lap-phase-repro.js
@@ -69,7 +69,9 @@ function makeApp() {
   src += '\n;this.__api={getUserInterface:typeof getUserInterface==="function"?getUserInterface:null,' +
     'onLoad:onLoad,evaluate:evaluate,onEvent:onEvent,onLap:onLap,' +
     'onExerciseEnd:onExerciseEnd,onExercisePause:onExercisePause,onExerciseContinue:onExerciseContinue,' +
-    'getState:function(){return state},getRoutes:function(){return routes},' +
+    'getState:function(){return state},' +
+    // routes are packed into routesA/routesB now — reconstruct the boxed [grade,send,cm,height,dur,hrAvg] tuples so existing assertions still read .length and [i][k].
+    'getRoutes:function(){var _o=[];for(var _i=0;_i<routesA.length;_i++)_o.push([Math.floor(routesA[_i]/1e6),Math.floor(routesA[_i]/1e5)%10,Math.floor(routesA[_i]/1e4)%10,routesA[_i]%1e4,Math.floor(routesB[_i]/1000),routesB[_i]%1000]);return _o},' +
     'getFrDirty:function(){return frDirty},' +
     'getLimit:function(){return ROUTE_LIMIT},' +
     'getExtLapPending:function(){return typeof extLapPending==="undefined"?undefined:extLapPending}};';

--- a/tools/tests/route-pack-equiv.js
+++ b/tools/tests/route-pack-equiv.js
@@ -1,0 +1,59 @@
+// route-pack-equiv.js — proves the routesA/routesB pack (main.js) is a lossless replacement for the old
+// boxed routes[] of [grade,send,cm,height,dur,hrAvg]. Route records never cross a build/manifest boundary,
+// so build-app.js is blind to a mis-pack — this is the only safety net. Mirror of main.js packA/packB +
+// rGrade/rSend/rCm/rHt/rDur/rHr + wGrade/wSend/wCm. If you change the pack in main.js, change it here too.
+//
+//   A = grade*1e6 + send*1e5 + cm*1e4 + height(0..9999)
+//   B = dur(0..86399)*1000 + hrAvgHz   (Hz kept fractional; the low fractional digits carry tiny float
+//       noise next to a large dur, but hr is only summed/averaged in ext19 and rendered bpm-rounded.)
+// Run: node tools/tests/route-pack-equiv.js
+
+var packA = function(g, s, c, h) { return g * 1e6 + s * 1e5 + c * 1e4 + Math.min(9999, Math.max(0, Math.round(h))); };
+var packB = function(d, hr) { return Math.min(86399, Math.max(0, Math.round(d))) * 1000 + (hr > 0 ? hr : 0); };
+var rGrade = function(A) { return Math.floor(A / 1e6); };
+var rSend  = function(A) { return Math.floor(A / 1e5) % 10; };
+var rCm    = function(A) { return Math.floor(A / 1e4) % 10; };
+var rHt    = function(A) { return A % 1e4; };
+var rDur   = function(B) { return Math.floor(B / 1000); };
+var rHr    = function(B) { return B % 1000; };
+// writers must change exactly ONE field, preserving the others (mirror of main.js wGrade/wSend/wCm)
+var wGrade = function(A, v) { return packA(v, rSend(A), rCm(A), rHt(A)); };
+var wSend  = function(A, v) { return packA(rGrade(A), v, rCm(A), rHt(A)); };
+var wCm    = function(A, v) { return packA(rGrade(A), rSend(A), v, rHt(A)); };
+
+var fails = 0, hrMaxErr = 0;
+var check = function(c, m) { if (!c) { console.log("  FAIL  " + m); fails++; } };
+
+// ---- exhaustive round-trip over the legal domain ----
+// grade index 0..40 (GRADE_LENS max 41), send 0/1, cm 0..5, height (clamped 9999), dur (clamped 86399), hr Hz
+var heights = [0, 1, 250, 9998, 9999, 12345];   // 12345 must clamp to 9999
+var durs    = [0, 1, 60, 3599, 86399, 99999];    // 99999 must clamp to 86399
+var hrs     = [0, 0.5, 1.234, 2.0, 3.999, 4];
+console.log("[route-pack] grade/send/cm/height/dur round-trip (must be EXACT)");
+for (var g = 0; g <= 40; g++) for (var s = 0; s <= 1; s++) for (var c = 0; c <= 5; c++)
+  for (var hi = 0; hi < heights.length; hi++) for (var di = 0; di < durs.length; di++) for (var ri = 0; ri < hrs.length; ri++) {
+    var A = packA(g, s, c, heights[hi]), B = packB(durs[di], hrs[ri]);
+    var eh = Math.min(9999, heights[hi]), ed = Math.min(86399, durs[di]);
+    check(rGrade(A) === g, "grade " + g);
+    check(rSend(A) === s, "send " + s);
+    check(rCm(A) === c, "cm " + c);
+    check(rHt(A) === eh, "height " + heights[hi] + " -> " + rHt(A));
+    check(rDur(B) === ed, "dur " + durs[di] + " -> " + rDur(B));
+    var herr = Math.abs(rHr(B) - (hrs[ri] > 0 ? hrs[ri] : 0)); if (herr > hrMaxErr) hrMaxErr = herr;
+  }
+console.log("  max hr float-noise: " + hrMaxErr.toExponential(2) + " Hz = " + (hrMaxErr * 60).toFixed(5) + " bpm (display rounds to integer bpm)");
+check(hrMaxErr < 1e-6, "hr noise must be < 1e-6 Hz");
+
+// ---- field-isolation: each writer changes ONLY its field ----
+console.log("[route-pack] writers isolate their field (no cross-field corruption)");
+var A0 = packA(18, 1, 3, 4567);  // grade 18, send 1, cm 3, height 4567
+check(rGrade(wGrade(A0, 7)) === 7 && rSend(wGrade(A0, 7)) === 1 && rCm(wGrade(A0, 7)) === 3 && rHt(wGrade(A0, 7)) === 4567, "wGrade changes only grade");
+check(rSend(wSend(A0, 0)) === 0 && rGrade(wSend(A0, 0)) === 18 && rCm(wSend(A0, 0)) === 3 && rHt(wSend(A0, 0)) === 4567, "wSend changes only send");
+check(rCm(wCm(A0, 5)) === 5 && rGrade(wCm(A0, 5)) === 18 && rSend(wCm(A0, 5)) === 1 && rHt(wCm(A0, 5)) === 4567, "wCm changes only cm");
+
+// ---- float32-irrelevance note: these are float64 app-internal, must stay < 2^53 ----
+console.log("  max packA = " + packA(40, 1, 5, 9999) + " ; max packB = " + packB(86399, 4) + "  (limit 2^53 = " + Math.pow(2, 53) + ")");
+check(packA(40, 1, 5, 9999) < Math.pow(2, 53) && packB(86399, 4) < Math.pow(2, 53), "packs must stay in float64 exact-int range");
+
+console.log(fails === 0 ? "\nALL PASS" : "\n" + fails + " FAILURE(S)");
+process.exit(fails === 0 ? 0 : 1);


### PR DESCRIPTION
**Stacked on the mount-diet** → this branch = packing + HR-pack + DOM diet + LIMIT split + **route-record packing**. The full footprint reduction on both memory pools.

## Why (on-watch 2026-06-16)
The diet fixed the **exec:ui** swipe crash — climb-logger survived; the *other* apps got evicted instead. But that exposed the next ceiling, **exec:zapp (JS heap)**: at 30+ routes the heap fills with boxed route records, then `onExerciseEnd`'s `ext19` summary parse tips it over →
```
relMemCb (exec:zapp) → RelMem->None avail → JSalloc:2139 → freeze   ("freeze on end")
```
The route records are the heap growth. (Codex's instinct to cut the heap was right; the target — `main.js` bytecode via a scope-broken `evalFile` — was wrong. This packs the actual data.)

## What
Semantic port of PR #135 onto the diverged diet branch: `routes[]` of 6-field JS arrays (~120 B/route) → 2 parallel float64 arrays `routesA`/`routesB` (~16 B/route) → **~5.2 KB reclaimed at the 50-route cap**.
- `A = grade*1e6 + send*1e5 + cm*1e4 + height(0..9999)` · `B = dur(0..86399)*1000 + hrAvgHz`
- App-internal only (never crosses the float32 output transit) → float64's 2⁵³ exact-int range holds the packs. `hrAvg` stays Hz (ext19 renders ×60).
- Accessors `rGrade/rSend/rCm/rHt/rDur/rHr` + writers `wGrade/wSend/wCm` are top-level fns (out of the dispatcher-compile budget). All 38 access points ported, including `rescanBest`, the pushEdit arrows, and the `wGL`/`wBrk` output writers. `ext19(rA,rB,gs)` unpacks inline; `ext14`'s slot-tag moved to a `wCm` in `saveAsProject`.

## Verification
build-app **Build successful** · validate **true** · output↔manifest lint **clean** · **route-pack-equiv ALL PASS** (integer fields exact; hr float-noise 2.6e-9 Hz) · output-pack-equiv ALL PASS · **lap-phase-repro ALL PASS @35** (commit / delete / un-send / grade-edit / prev-nav all through the packed accessors).

## Before merge / flash
- ⚠️ `ROUTE_LIMIT` still **999** (TEMP) — revert to 35 before merge.
- ⚠️ `.fea` not in PR — rebuild in VS Code before flashing.
- Unlike Codex's change, this is **node-harness-testable** (no watch-only scope dependency) — but the real proof is on-watch: does a 30+ route session now save/end without the JSalloc freeze, and do all 3 apps survive longer?

🤖 Generated with [Claude Code](https://claude.com/claude-code)