### PR TITLE
perf+fix: active.html measure-pass diet (27→8) + exec:zapp save-survival (40+ routes on-watch)

### DIFF
--- a/active.html
+++ b/active.html
@@ -4,8 +4,9 @@
           var G='3a,3a+,3b,3b+,3c,3c+,4a,4a+,4b,4b+,4c,4c+,5a,5a+,5b,5b+,5c,5c+,6a,6a+,6b,6b+,6c,6c+,7a,7a+,7b,7b+,7c,7c+,8a,8a+,8b,8b+,8c,8c+,9a,9a+,9b,9b+,9c|4,4+,5-,5,5+,6-,6,6+,7-,7,7+,8-,8,8+,9-,9,9+,10-,10,10+,11-,11,11+,12-|5.5,5.6,5.7,5.8,5.9,5.10a,5.10b,5.10c,5.10d,5.11a,5.11b,5.11c,5.11d,5.12a,5.12b,5.12c,5.12d,5.13a,5.13b,5.13c,5.13d,5.14a,5.14b,5.14c,5.14d,5.15a,5.15b,5.15c,5.15d|4a,4b,4c,5a,5b,5c,6a,6b,6c,7a,7b|VB,V0,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12|4A,4A+,4B,4B+,4C,4C+,5A,5A+,5B,5B+,5C,5C+,6A,6A+,6B,6B+,6C,6C+,7A,7A+,7B,7B+,7C,7C+,8A,8A+,8B,8B+,8C,8C+|WI2,WI3,WI3+,WI4,WI4+,WI5,WI5+,WI6,WI6+,WI7,WI7+|M1,M2,M3,M4,M5,M6,M7,M8,M9,M10,M11,M12|Set|Lap'.split('|');
           var Gs=null,Gsi=-1;
           function dG(x){if(x<0)return'--';if(x%100>=50)return'OFF';var si=Math.floor(x/100);if(si!==Gsi){Gs=(G[si]||'').split(',');Gsi=si}return(Gs||[])[x%100]||'?'}
-          var lapState=0,lock=0;
+          var lapState=-1,lock=0;
           function applyVis(x){
+            if(x===lapState)return;
             lapState=x;
             setStyle('#sc0','visibility',x===0?'VISIBLE':'HIDDEN');
             setStyle('#sc1','visibility',x===1?'VISIBLE':'HIDDEN');
@@ -27,27 +28,31 @@
     <div id="sc0" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:VISIBLE">
 
       <div onTap="ev(1)" style="top:17%;left:0;width:70%;height:22%;position:absolute;"></div>
-      <div class="f-ico p-hc" style="top:calc(36% - 50%e);">&#xF266;</div>
+      <!-- icon centerings use a fixed 18.5px (= half f-ico's 37px line-height) instead of 50%e,
+           so the firmware skips a per-element self-measure (proportionOfElement) at mount.
+           Identical pixels; verified against the compiled active.xml. Text rows keep 50%e
+           (their height isn't a single fixed glyph). -->
+      <div class="f-ico p-hc" style="top:calc(36% - 18.5px);">&#xF266;</div>
 
-      <div class="sp-t-l" style="top:calc(48% - 50%e); left:calc(50% - 50%e);">
+      <div class="sp-t-l" style="top:calc(48% - 36.5px); left:calc(50% - 50%e);">
         <eval input="/Zapp/{zapp_index}/Output/packedGL" outputFormat="script x => dG(Math.floor(x/952))" default="--" />
       </div>
 
       <div onTap="ev(2)" style="top:57%;left:0;width:70%;height:25%;position:absolute;"></div>
-      <div class="f-ico p-hc" style="top:calc(66% - 50%e);">&#xF267;</div>
+      <div class="f-ico p-hc" style="top:calc(66% - 18.5px);">&#xF267;</div>
 
       <div style="top:18%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
-        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE338;</div>
+        <div class="f-ico cm-bgc" style="top:calc(50% - 18.5px); left:6px;">&#xE338;</div>
       </div>
       <div onTap="evX(5)" style="top:11%;left:70%;width:30%;height:25%;position:absolute;"></div>
 
       <div style="top:44%;left:90%;width:10%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
-        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xF111;</div>
+        <div class="f-ico cm-bgc" style="top:calc(50% - 18.5px); left:6px;">&#xF111;</div>
       </div>
       <div onTap="ev(4)" style="top:37%;left:70%;width:30%;height:25%;position:absolute;"></div>
 
       <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
-        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE373;</div>
+        <div class="f-ico cm-bgc" style="top:calc(50% - 18.5px); left:6px;">&#xE373;</div>
       </div>
       <div onTap="evL(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
 
@@ -55,7 +60,7 @@
            are -1 in non-project mode → script formats return '' to hide. Migrated from
            setText to output bindings because sc0 is HIDDEN when goState(0) runs from
            the event handler — setText on hidden elements is a silent no-op. -->
-      <div class="p-hc sp-vertical-center" style="top:calc(78% - 50%e);">
+      <div class="p-hc sp-vertical-center" style="top:calc(78% - 20.5px);">
         <span class="sp-b-s"><eval input="/Zapp/{zapp_index}/Output/actT" outputFormat="script x => x < 0 ? '' : x + 'T'" default="" /></span>
         <span class="sp-b-s" style="padding-left:6px"><eval input="/Zapp/{zapp_index}/Output/actS" outputFormat="script x => x < 0 ? '' : x + 'S'" default="" /></span>
         <span class="sp-b-s" style="padding-left:6px"><eval input="/Zapp/{zapp_index}/Output/actB" outputFormat="script x => x <= 0 ? '' : Math.floor(x/60) + ':' + ('0'+(x%60)).slice(-2)" default="" /></span>
@@ -71,14 +76,14 @@
 
       <div class="p-hc" style="top:44%;width:70%;height:2px;background:rgba(255,255,255,0.3)"></div>
 
-      <div class="sp-vertical-center" style="top:calc(55% - 50%e); left:calc(30% - 50%e);">
+      <div class="sp-vertical-center" style="top:calc(55% - 24.5px); left:calc(30% - 50%e);">
         <span class="sp-b-s">H</span>
         <span class="sp-b-m f-num" style="padding-left:4px"><eval input="/Zapp/{zapp_index}/Output/routeHeight" outputFormat="script x => (x>=0?'+':'')+x+'m'" default="0m" /></span>
       </div>
 
       <div class="p-hc" style="top:49%;width:2px;height:14%;background:rgba(255,255,255,0.3)"></div>
 
-      <div class="sp-vertical-center" style="top:calc(55% - 50%e); left:calc(70% - 50%e);">
+      <div class="sp-vertical-center" style="top:calc(55% - 24.5px); left:calc(70% - 50%e);">
         <span class="f-ico" style="padding-right:4px">&#xF144;</span>
         <span class="sp-b-m"><eval input="/Zapp/{zapp_index}/Output/packedGL" outputFormat="script x => dG(Math.floor(x/952))" default="--" /></span>
       </div>
@@ -90,26 +95,26 @@
 
 
       <div style="top:18%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
-        <div class="f-ico" style="top:calc(50% - 50%e); left:6px;color:#fff;">&#xF110;</div>
+        <div class="f-ico" style="top:calc(50% - 18.5px); left:6px;color:#fff;">&#xF110;</div>
       </div>
       <div onTap="evL(5)" style="top:11%;left:70%;width:30%;height:25%;position:absolute;"></div>
 
       <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
-        <div class="f-ico" style="top:calc(50% - 50%e); left:6px;color:#fff;">&#xF200;</div>
+        <div class="f-ico" style="top:calc(50% - 18.5px); left:6px;color:#fff;">&#xF200;</div>
       </div>
       <div onTap="evL(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
     </div>
 
     <div id="sc2" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:HIDDEN">
 
-      <div class="sp-vertical-center" style="top:calc(27% - 50%e); left:calc(30% - 50%e);">
+      <div class="sp-vertical-center" style="top:calc(27% - 24.5px); left:calc(30% - 50%e);">
         <span class="f-ico" style="padding-right:4px">&#xF144;</span>
         <span class="sp-b-m"><eval input="/Zapp/{zapp_index}/Output/packedGL" outputFormat="script x => dG(x%952-1)" default="--" /></span>
       </div>
 
       <div class="p-hc" style="top:22%;width:2px;height:14%;background:rgba(255,255,255,0.3)"></div>
 
-      <div class="sp-vertical-center" style="top:calc(27% - 50%e); left:calc(70% - 50%e);">
+      <div class="sp-vertical-center" style="top:calc(27% - 24.5px); left:calc(70% - 50%e);">
         <span class="f-ico" style="padding-right:4px">&#xF100;</span>
         <span class="sp-b-m"><eval input="/Activity/Lap/-2/Duration/Current" outputFormat="Duration_FourdigitsFixed" default="0:00" /></span>
       </div>
@@ -136,7 +141,7 @@
 
       <div class="p-hc" style="top:57%;width:70%;height:2px;background:rgba(255,255,255,0.3)"></div>
 
-      <div class="p-hc sp-vertical-center" style="top:calc(64% - 50%e);">
+      <div class="p-hc sp-vertical-center" style="top:calc(64% - 20.5px);">
         <span class="f-ico" style="padding-right:14px">&#xF107;</span>
         <span class="f-ico" style="padding-right:6px">&#xF200;</span>
         <span class="sp-b-s f-num"><eval input="/Zapp/{zapp_index}/Output/packedBreak" outputFormat="script x => ''+(Math.floor(x/64)%64)" default="0" /></span><span class="sp-b-s f-num">/</span><span class="sp-b-s f-num"><eval input="/Zapp/{zapp_index}/Output/packedBreak" outputFormat="script x => ''+(x%64)" default="0" /></span>
@@ -146,19 +151,19 @@
         <span class="sp-b-s f-num" style="padding-left:3px"><eval input="/Zapp/{zapp_index}/Output/routeHeight" outputFormat="script x => (x>=0?'+':'') + x + 'm'" default="--" /></span>
       </div>
 
-      <div class="p-hc sp-vertical-center" style="top:calc(77% - 50%e);">
+      <div class="p-hc sp-vertical-center" style="top:calc(77% - 20.5px);">
         <span class="f-ico sp-c-red" style="padding-right:4px">&#xF101;</span>
         <span class="sp-b-s f-num"><eval input="/Activity/Move/-1/Heartrate/Current" outputFormat="HeartRate_Fourdigits" default="--" /></span>
       </div>
 
 
       <div style="top:44%;left:90%;width:10%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
-        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE338;</div>
+        <div class="f-ico cm-bgc" style="top:calc(50% - 18.5px); left:6px;">&#xE338;</div>
       </div>
       <div onTap="evX(4)" style="top:37%;left:70%;width:30%;height:25%;position:absolute;"></div>
 
       <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
-        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE373;</div>
+        <div class="f-ico cm-bgc" style="top:calc(50% - 18.5px); left:6px;">&#xE373;</div>
       </div>
       <div onTap="evX(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
     </div>
@@ -167,7 +172,7 @@
          identical content; authored once here (rendered last so it sits above the section tops). Saves
          2 cm-fg bands + 2 evals + 2 self-size measure-passes from the resident active mount. -->
     <div class="cm-fg" style="width:100%;height:16%">
-      <div class="sp-t-s p-hc" style="top:calc(50% - 50%e);">
+      <div class="sp-t-s p-hc" style="top:calc(50% - 19px);">
         <eval input="/Zapp/{zapp_index}/Output/modeSub" outputFormat="script x => x > 0 ? 'ROUTE ' + x : 'PROJECT ' + Math.abs(x)" default="ROUTE 1" />
       </div>
     </div>
@@ -176,7 +181,7 @@
          diamond, which was a costly per-pixel mask; plain rgba rectangles cost essentially nothing to mount). -->
     <div class="p-hc" style="top:87%;width:70%;height:9%;background:rgba(255,255,255,0.12)"></div>
     <div class="p-hc" style="top:87%;width:70%;height:2px;background:rgba(255,255,255,0.3)"></div>
-    <div class="p-hc sp-vertical-center" style="top:calc(90% - 50%e);">
+    <div class="p-hc sp-vertical-center" style="top:calc(90% - 20.5px);">
       <span class="sp-b-s f-num"><eval input="/Dev/Time/LocalTime" outputFormat="script x => ('0'+Math.floor((x/3600)%24)).slice(-2)+':'+('0'+Math.floor((x/60)%60)).slice(-2)" default="--:--" /></span>
       <span class="f-ico" style="padding-left:6px;padding-right:6px">&#xF100;</span>
       <span class="sp-b-s f-num"><eval input="/Activity/Move/-1/Duration/Current" outputFormat="Duration_FourdigitsFixed" default="0:00" /></span>
@@ -185,14 +190,19 @@
     <!-- Physical pushButtons — universal events, main.js dispatches by state -->
     <:if test="{{ HAS_ON_EVENT }}">
     <userInput>
+      <!-- onLongPressFull consumes the full long-press phase so the firmware button defaults
+           (up=Multisport, down=Control Panel) don't fire on the app's up/down long-press actions —
+           including entering EDIT/proj-setup from READY. 'next' stays free (middle = screen nav). -->
       <pushButton name="up" type="lock" longType="lock"
         onClick="ev(1)"
-        onLongPressStart="evL(5)" />
+        onLongPressStart="evL(5)"
+        onLongPressFull=";" />
       <pushButton name="next" longType="lock"
         onLongPressStart="ev(4)" />
       <pushButton name="down" type="lock" longType="lock"
         onClick="ev(2)"
-        onLongPressStart="evL(6)" />
+        onLongPressStart="evL(6)"
+        onLongPressFull=";" />
     </userInput>
     </:if>
 

--- a/edit.html
+++ b/edit.html
@@ -69,14 +69,17 @@
     <!-- Physical pushButtons — universal events, main.js dispatches by state -->
     <:if test="{{ HAS_ON_EVENT }}">
     <userInput>
+      <!-- onLongPressFull consumes the firmware up=Multisport / down=Control Panel default; middle free. -->
       <pushButton name="up" type="lock" longType="lock"
         onClick="ev(1)"
-        onLongPressStart="evL(5)" />
+        onLongPressStart="evL(5)"
+        onLongPressFull=";" />
       <pushButton name="next" longType="lock"
         onLongPressStart="ev(4)" />
       <pushButton name="down" type="lock" longType="lock"
         onClick="ev(2)"
-        onLongPressStart="evL(6)" />
+        onLongPressStart="evL(6)"
+        onLongPressFull=";" />
     </userInput>
     </:if>
 

--- a/limit.html
+++ b/limit.html
@@ -18,14 +18,17 @@
     <!-- Physical pushButtons — universal events, main.js dispatches by state (state 3 → any event = READY) -->
     <:if test="{{ HAS_ON_EVENT }}">
     <userInput>
+      <!-- onLongPressFull consumes the firmware up=Multisport / down=Control Panel default; middle free. -->
       <pushButton name="up" type="lock" longType="lock"
         onClick="ev(1)"
-        onLongPressStart="evL(5)" />
+        onLongPressStart="evL(5)"
+        onLongPressFull=";" />
       <pushButton name="next" longType="lock"
         onLongPressStart="ev(4)" />
       <pushButton name="down" type="lock" longType="lock"
         onClick="ev(2)"
-        onLongPressStart="evL(6)" />
+        onLongPressStart="evL(6)"
+        onLongPressFull=";" />
     </userInput>
     </:if>
 

--- a/main.js
+++ b/main.js
@@ -641,7 +641,7 @@ function onExerciseEnd(input, _output) {
       LS.setObject("lastSummary", fb);
     }
   } catch (e) {}
-  if (pendF17) { pendF17 = 0; try { loadExt(17)(gradeSystem); } catch (e) {} }  // drain pending snapshot-swap — parse-on-use (ext17 not cached resident)
+  if (pendF17) { try { loadExt(17)(gradeSystem); pendF17 = 0; } catch (e) {} }  // drain pending snapshot-swap — parse-on-use (ext17 not cached resident); clear pendF17 only AFTER a successful parse, so an evicted ext17 in a heap-full save window retries next end instead of silently dropping the grade-system snapshot
   try { LS.setObject("climbProjStats", projStats); } catch (e) {}
   projStatsDirty = 0;
   if (wsDirty) { wsDirty = 0; try { saveSetup(); } catch (e) {} }  // deferred watchSetup persist (defer-to-end pattern)

--- a/main.js
+++ b/main.js
@@ -49,6 +49,7 @@ var extLapPending = 0;  // deferred CLIMB-finish armed by an EXTERNAL lap (auto-
 var editIdx = 0;
 var editDelMark = 0;
 var isPaused = 0;
+var finalized = 0;  // onExerciseEnd idempotency (fast pause→end guard); reset to 0 in onLoad each session
 var pStep = 0;
 var dwell = 0;  // CLIMB-entry guard — cleared at end of next evaluate tick
 var pendF17 = 0;
@@ -71,7 +72,7 @@ var DEFAULT_IDX = [18, 6, 5, 5, 4, 12, 3, 5, 0, 0];
 var gradeSystem = 0;
 var LS = localStorage;
 var loadExt = function(n) { return evalFile('{file_path}/ext' + n + '.js'); };
-var f10, f11, f17;  // T7: cache parsed ext fns; per-route re-parse was heap-fragmenting
+var f10;  // cache ONLY ext10 (called per ROUTE — per-route re-parse was heap-fragmenting, the T7 reason). ext11 (writeStats) + ext17 (grade-swap) each run ONCE at session end, so caching them held ~2.3KB resident the WHOLE session for nothing; now parsed on-demand at onExerciseEnd → frees that resident RAM all session (more swap-budget headroom).
 
 // Start-screen rule — single source of truth for getUserInterface() + onLoad(): returning user with a
 // saved setup and showSetupOnStart off → READY (active cluster); otherwise first-run SETUP (manage).
@@ -103,7 +104,7 @@ var loadProjects = function(sys) {
 };
 
 var writeStats = function() {
-  f11(allTimeStats, projGradeIdx, projStats, climbMode, gradeSystem);
+  loadExt(11)(allTimeStats, projGradeIdx, projStats, climbMode, gradeSystem);  // parse-on-use: ext11 NOT cached (single end-of-session call) → off the resident heap all session
 };
 
 var saveSetup = function() {
@@ -337,8 +338,8 @@ var commitDirty = function(input) {
     lastDuration = rSec;  // no input.D fallback: a sub-second route (rSec=0) logged a firmware-LAP duration (wrong unit/scope -> ~99999s, displayed 1666:39, poisoned project bestTime). Honest 0:00 instead.
     lastPk1 = bestPk1 || lastHrAvg;
     lastPk3 = bestPk3 || lastHrAvg;
-    var r = f10(lastGradeIdx, gradeSystem, lastDuration, lastHrAvg, hrMax || (input.M || 0), lastPk1, lastPk3,
-      frSend, lastClimbMode, bestSendIdx, projStats, allTimeStats, lastHeight);  // lastClimbMode (slot at finish), NOT live climbMode — cycleSlot in BREAK must not re-tag this route
+    var r = (f10 || (f10 = loadExt(10)))(lastGradeIdx, gradeSystem, lastDuration, lastHrAvg, hrMax || (input.M || 0), lastPk1, lastPk3,
+      frSend, lastClimbMode, bestSendIdx, projStats, allTimeStats, lastHeight);  // lazy-parse ext10 on the FIRST route, cached for the session (NOT per-route — the T7 reason); keeps it out of the onLoad/re-enable burst. lastClimbMode (slot at finish), NOT live climbMode — cycleSlot in BREAK must not re-tag this route
     bestSendIdx = r[0];
     if (r[2]) {
       var rec = r[2];  // [grade, send, cm, height, dur, hrAvg] transient from ext10 (f10) — packed here, not stored boxed
@@ -447,8 +448,7 @@ var evSetup = function(output, eid, dy) {
     gradeV = encGrade(DEFAULT_IDX[gradeSystem]); wGL(output);
     output.modeSub = gradeSystem;
     wsDirty = 1;   // watchSetup needs persisting at session end
-    pendF17 = 1;   // ext17 grade-system snapshot swap also runs at session end
-    f17 = f17 || loadExt(17);  // lazy-cache here (deferred from onLoad); pendF17 ⇒ f17 ready by onExerciseEnd
+    pendF17 = 1;   // ext17 grade-system snapshot swap runs once at session end (parsed on-demand THERE — not cached resident)
   } else if (eid === 6) {
     goState(0, output);  // instant — saveSetup deferred to onExerciseEnd (defer-to-end)
   }
@@ -556,7 +556,10 @@ var evEdit = function(output, eid) {
 };
 
 function onLoad(_input, output) {
-  f10 = loadExt(10); f11 = loadExt(11);  // T7: cache once (f17 lazy-loaded on first grade-system change — see evSetup; trims startup evalFile burst)
+  finalized = 0;  // new session → re-arm onExerciseEnd
+  // f10 (ext10) is NOT parsed here — lazy at the first commitDirty (it isn't needed until a route
+  // finishes). Keeps the onLoad/re-enable parse burst to ONE file (ext12 bootstrap), so a fast
+  // disable→enable is less likely to race the firmware's not-yet-reclaimed prior instance into None-avail.
   var r = loadExt(12)(allTimeStats);
   gradeSystem = r[0];
   projGradeIdx = r[1];
@@ -605,6 +608,7 @@ function evaluate(input, output) {
 }
 
 function onExerciseEnd(input, _output) {
+  if (finalized) return; finalized = 1;  // idempotent: a fast pause→end (or any double-fire) must not re-run the parse burst on an already-stressed heap
   if (state === 1) {
     lastGradeIdx = currentGrade; lastClimbMode = climbMode;  // mirror finishRoute's slot snapshot for the end-of-session pending route
     lastHeight = Math.max(0, Math.round(curAsc - startAsc));
@@ -614,7 +618,30 @@ function onExerciseEnd(input, _output) {
     routeNumber++;
   }
   try { commitDirty(input); } catch (e) { LS.setObject("dbgEndErr", { msg: "" + e }); }
-  if (pendF17) { pendF17 = 0; try { f17(gradeSystem); } catch (e) {} }  // drain pending snapshot-swap
+  // Fast disable→enable safeguard: if this session logged/changed NOTHING (no routes, no dirty
+  // project/setup/grade state), skip the whole save burst (ext11/ext19 parses + LS writes). On a FAST
+  // re-enable those parses race the firmware's not-yet-reclaimed prior instance → relMemCb(exec:zapp)/
+  // None-avail → cascade → watch ASSERT/reboot (log 2026-06-19 16:04:22, routesA empty). Nothing to
+  // persist, so bail — leaving the disabled instance light enough for the re-enable's onLoad to fit.
+  if (routesA.length === 0 && !projStatsDirty && !wsDirty && !pendF17) return;
+  // Free exec:zapp heap BEFORE the end-parse burst (loadExt 17/11/19). The save was evicting with
+  // relMemCb(exec:zapp)/None-avail because three back-to-back evalFile parses hit a full heap. hrBuf
+  // (180-slot HR ring) + f10 (ext10 closure) are dead after the climb is over — commitDirty above was
+  // their last consumer. routesA/routesB (ext19) and projStats/allTimeStats (ext11) stay live.
+  hrBuf = null; hrIdx = 0; f10 = null;
+  // Parse-free fallback summary FIRST, so an eviction during the ext11/ext19 parse can never leave
+  // "0/0": ext19 overwrites this with the rich recap if its parse survives. Sends counted via rSend
+  // exactly like ext19 (no drift), no evalFile, no allocation beyond the tiny array.
+  try {
+    if (routesA.length > 0) {
+      var sFb = 0, iFb;
+      for (iFb = 0; iFb < routesA.length; iFb++) { if (rSend(iFb)) sFb++; }
+      var fb = [{ id: 'sr', name: 'Sends / Routes', format: 'Count_Fourdigits', value: sFb, postfix: '/ ' + routesA.length }];
+      if (sessionH > 0) { fb.push({ id: 'h', name: 'Height', format: 'Count_Fourdigits', value: Math.round(sessionH), postfix: 'm' }); }
+      LS.setObject("lastSummary", fb);
+    }
+  } catch (e) {}
+  if (pendF17) { pendF17 = 0; try { loadExt(17)(gradeSystem); } catch (e) {} }  // drain pending snapshot-swap — parse-on-use (ext17 not cached resident)
   try { LS.setObject("climbProjStats", projStats); } catch (e) {}
   projStatsDirty = 0;
   if (wsDirty) { wsDirty = 0; try { saveSetup(); } catch (e) {} }  // deferred watchSetup persist (defer-to-end pattern)

--- a/manage.html
+++ b/manage.html
@@ -97,14 +97,20 @@
     <!-- Physical pushButtons — universal events, main.js dispatches by state -->
     <:if test="{{ HAS_ON_EVENT }}">
     <userInput>
+      <!-- onLongPressFull=";" consumes the firmware up=Multisport / down=Control-Panel long-press default.
+           The SETUP→active SCREEN-JUMP itself is fixed centrally in main.js (pendBack: the goState(0) swap is
+           deferred one evaluate tick, so the tap/button input drains before the unload remount — fixes tap
+           AND button AND the touch pills uniformly). 'next' stays free (middle = screen nav). -->
       <pushButton name="up" type="lock" longType="lock"
         onClick="ev(1)"
-        onLongPressStart="evL(5)" />
+        onLongPressStart="evL(5)"
+        onLongPressFull=";" />
       <pushButton name="next" longType="lock"
         onLongPressStart="ev(4)" />
       <pushButton name="down" type="lock" longType="lock"
         onClick="ev(2)"
-        onLongPressStart="evL(6)" />
+        onLongPressStart="evL(6)"
+        onLongPressFull=";" />
     </userInput>
     </:if>
 

--- a/manage.html
+++ b/manage.html
@@ -98,9 +98,9 @@
     <:if test="{{ HAS_ON_EVENT }}">
     <userInput>
       <!-- onLongPressFull=";" consumes the firmware up=Multisport / down=Control-Panel long-press default.
-           The SETUP→active SCREEN-JUMP itself is fixed centrally in main.js (pendBack: the goState(0) swap is
-           deferred one evaluate tick, so the tap/button input drains before the unload remount — fixes tap
-           AND button AND the touch pills uniformly). 'next' stays free (middle = screen nav). -->
+           The SETUP→active SCREEN-JUMP (the unload+remount IS the co-app evict, confirmed on-watch) is
+           mitigated by the active.html mount diet — a lighter remount peak, NOT input deferral. (An earlier
+           pendBack "defer goState(0) one tick" attempt was tried and reverted.) 'next' stays free (middle = screen nav). -->
       <pushButton name="up" type="lock" longType="lock"
         onClick="ev(1)"
         onLongPressStart="evL(5)"


### PR DESCRIPTION
On-watch validated (40+ routes). Stacked on #142 (header dedup).

## exec:ui mount axis — FIXED
active.html self-measure passes (`calc(%e)` → fixed px, computed from q-display font line-heights): **proportionOfElement 27 → 8** (9 icon + 10 text-row conversions; the 2 sp-d-* + 6 text-width horizontals kept). 40+ routes + screen-switching now run **clean in-session** — climb-logger is light enough that exec:ui pressure evicts a co-resident app, not us.

## exec:zapp save axis — survival
- Free `hrBuf`/`f10` before the end-parse burst + **parse-free fallback `lastSummary`** (never 0/0) + idempotent `finalized` guard (fast pause→end).
- Skip the save burst on an empty session (fast disable→enable safeguard).
- `f11`/`f17` parse-on-demand (not cached) + `f10` lazy at first commit → **~2.3 KB resident freed** all session; onLoad/re-enable parses only `ext12`.
- Route ceiling **23-25 → 40+** on-watch.

## SETUP/EDIT buttons
`onLongPressFull=";"` consumes the firmware up=Multisport / down=Control-Panel default; middle (`next`) stays free for screen nav.

## Known-open (NOT in this PR)
At 40+ routes the save-window heap can still exhaust (evicts Movement+Weather) → `data.jsn` mid-write corruption → tracked in **#143** (deep fix = incremental recap aggregates → free routesA/B before the ext19 parse, separate PR).

## Before merge
- Revert `ROUTE_LIMIT` 999 → 35 (temp probe value).
- Rebuild `climbl01-q.fea` in VS Code (not committed here per convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KU3vC9Zc73BWNx3VefKGZj