### PR TITLE
perf: split proj-setup into projsetup.html — lighten the manage→active remount (co-app evict)

### DIFF
--- a/main.js
+++ b/main.js
@@ -246,7 +246,7 @@ var pushEdit = function() {
 
 var goState = function(s, output) {
   state = s;
-  var t = s < 3 ? "active" : s === 3 ? "limit" : s === 5 ? "edit" : "manage";  // 0/1/2 → active, 3 → dedicated limit.html, 5 → edit.html, 4/6 → manage
+  var t = s < 3 ? "active" : s === 3 ? "limit" : s === 5 ? "edit" : s === 6 ? "projsetup" : "manage";  // 0/1/2 → active, 3 → limit.html, 5 → edit.html, 6 → projsetup.html (in-session project config), 4 → manage.html (SETUP, first-launch only). sc6 split out of manage shrinks the project-save remount peak (resident sc4+sc6 → sc4 alone); no new swap since 4/6 are independent (never toggled against each other).
   var tChanged = (currentTemplate !== t);
   currentTemplate = t;
   if (tChanged) unload('_cm');

--- a/manage.html
+++ b/manage.html
@@ -51,39 +51,11 @@
 
     </div>
 
-    <!-- sc5 (EDIT) moved to dedicated edit.html (A+C restructure): entering EDIT now mounts ONLY the
-         edit screen, not SETUP sc4 + proj-setup sc6 + their weight — shrinks the EDIT mount transient. -->
-
-    <div id="sc6" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:HIDDEN">
-
-      <div class="sp-b-s p-hc" style="top:calc(22% - 50%e);">
-        <span>PROJECT </span>
-        <span class="f-num"><eval input="/Zapp/{zapp_index}/Output/modeSub" outputFormat="Count_Twodigits" default="1" /></span>
-      </div>
-
-      <div onTap="ev(1)" style="top:17%;left:0;width:70%;height:22%;position:absolute;"></div>
-      <div class="f-ico p-hc" style="top:calc(36% - 50%e);">&#xF266;</div>
-
-      <div class="sp-t-l" style="top:calc(48% - 50%e); left:calc(50% - 50%e);">
-        <eval input="/Zapp/{zapp_index}/Output/packedGL" outputFormat="script x => dG(Math.floor(x/952))" default="OFF" />
-      </div>
-
-      <div onTap="ev(2)" style="top:57%;left:0;width:70%;height:25%;position:absolute;"></div>
-      <div class="f-ico p-hc" style="top:calc(66% - 50%e);">&#xF267;</div>
-
-      <!-- Top pill (save & back to ready) — UP-long = save & back -->
-      <div style="top:18%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
-        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE365;</div>
-      </div>
-      <div onTap="evX(5)" style="top:11%;left:70%;width:30%;height:25%;position:absolute;"></div>
-
-      <!-- Bottom pill (save & next slot) — DOWN-long = save & weiter -->
-      <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
-        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE373;</div>
-      </div>
-      <div onTap="ev(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
-
-    </div>
+    <!-- sc5 (EDIT) moved to edit.html; sc6 (PROJECT-SETUP) moved to projsetup.html. manage.html is now
+         SETUP-only (state 4 = first-launch onboarding, never re-entered in-session). Splitting proj-setup
+         out shrinks the resident template at PROJECT-SAVE (the manage→active remount that was shedding a
+         co-app at 00:59:16 on 2026-06-26) from sc4+sc6 down to sc4 alone — and adds NO new swap, because
+         sc4/sc6 are independent (no goState(4) exists; eid5 from READY enters proj-setup directly). -->
 
     <!-- Bottom time-bar with a cheap flat-fill backing panel + top hairline (the old clip-path diamond was removed — masks are expensive, plain rgba rects are not). -->
     <div class="p-hc" style="top:87%;width:70%;height:9%;background:rgba(255,255,255,0.12)"></div>

--- a/manifest.json
+++ b/manifest.json
@@ -121,6 +121,17 @@
         "q",
         "s"
       ]
+    },
+    {
+      "name": "projsetup.html",
+      "displays": [
+        "l",
+        "m",
+        "n",
+        "o",
+        "q",
+        "s"
+      ]
     }
   ],
   "variables": [

--- a/projsetup.html
+++ b/projsetup.html
@@ -1,0 +1,81 @@
+<!-- PROJECT-SETUP screen (state 6), split out of manage.html so the manage→active remount on PROJECT-SAVE
+     mounts ONLY this lean single screen, not SETUP sc4 + proj-setup sc6 together. Single-view: no applyVis
+     / vState binding, no system-name table (SN/sN is SETUP-only). Vertical calc(Y%-50%e) measure-passes
+     converted to static px (f-ico 18.5 / sp-t-l 36.5 / sp-b-s 20.5) per the active.html diet; only the
+     grade-text horizontal centre keeps a self-width %e (variable-width text). -->
+<uiView onFlickUp="ev(7)"
+        onFlickDown="ev(8)"
+        onLoad="
+          var G='3a,3a+,3b,3b+,3c,3c+,4a,4a+,4b,4b+,4c,4c+,5a,5a+,5b,5b+,5c,5c+,6a,6a+,6b,6b+,6c,6c+,7a,7a+,7b,7b+,7c,7c+,8a,8a+,8b,8b+,8c,8c+,9a,9a+,9b,9b+,9c|4,4+,5-,5,5+,6-,6,6+,7-,7,7+,8-,8,8+,9-,9,9+,10-,10,10+,11-,11,11+,12-|5.5,5.6,5.7,5.8,5.9,5.10a,5.10b,5.10c,5.10d,5.11a,5.11b,5.11c,5.11d,5.12a,5.12b,5.12c,5.12d,5.13a,5.13b,5.13c,5.13d,5.14a,5.14b,5.14c,5.14d,5.15a,5.15b,5.15c,5.15d|4a,4b,4c,5a,5b,5c,6a,6b,6c,7a,7b|VB,V0,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12|4A,4A+,4B,4B+,4C,4C+,5A,5A+,5B,5B+,5C,5C+,6A,6A+,6B,6B+,6C,6C+,7A,7A+,7B,7B+,7C,7C+,8A,8A+,8B,8B+,8C,8C+|WI2,WI3,WI3+,WI4,WI4+,WI5,WI5+,WI6,WI6+,WI7,WI7+|M1,M2,M3,M4,M5,M6,M7,M8,M9,M10,M11,M12|Set|Lap'.split('|');
+          var Gs=null,Gsi=-1;
+          function dG(x){if(x<0)return'--';if(x%100>=50)return'OFF';var si=Math.floor(x/100);if(si!==Gsi){Gs=(G[si]||'').split(',');Gsi=si}return(Gs||[])[x%100]||'?'}
+          var lapState=4,lock=0;
+          function ev(n){$.put('/Zapp/{zapp_index}/Event',n,null,'int32')}
+          function lap(){$.put('/Activity/Trigger',23)}
+          function ulk(){lock=0}
+          function evX(n){if(lock)return;ev(n);lock=1;setTimeout(ulk,300)}
+          function evL(n){if(lock)return;var s=lapState;if((n===6&&s===0)||s===1)lap();ev(n);lock=1;setTimeout(ulk,300)}
+        ">
+  <div id="climblogger">
+
+    <div id="sc6" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:VISIBLE">
+
+      <div class="sp-b-s p-hc" style="top:calc(22% - 20.5px);">
+        <span>PROJECT </span>
+        <span class="f-num"><eval input="/Zapp/{zapp_index}/Output/modeSub" outputFormat="Count_Twodigits" default="1" /></span>
+      </div>
+
+      <div onTap="ev(1)" style="top:17%;left:0;width:70%;height:22%;position:absolute;"></div>
+      <div class="f-ico p-hc" style="top:calc(36% - 18.5px);">&#xF266;</div>
+
+      <div class="sp-t-l" style="top:calc(48% - 36.5px); left:calc(50% - 50%e);">
+        <eval input="/Zapp/{zapp_index}/Output/packedGL" outputFormat="script x => dG(Math.floor(x/952))" default="OFF" />
+      </div>
+
+      <div onTap="ev(2)" style="top:57%;left:0;width:70%;height:25%;position:absolute;"></div>
+      <div class="f-ico p-hc" style="top:calc(66% - 18.5px);">&#xF267;</div>
+
+      <!-- Top pill (save & back to ready) — UP-long = save & back -->
+      <div style="top:18%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
+        <div class="f-ico cm-bgc" style="top:calc(50% - 18.5px); left:6px;">&#xE365;</div>
+      </div>
+      <div onTap="evX(5)" style="top:11%;left:70%;width:30%;height:25%;position:absolute;"></div>
+
+      <!-- Bottom pill (save & next slot) — DOWN-long = save & weiter -->
+      <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
+        <div class="f-ico cm-bgc" style="top:calc(50% - 18.5px); left:6px;">&#xE373;</div>
+      </div>
+      <div onTap="ev(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
+
+    </div>
+
+    <!-- Bottom time-bar (shared flat-fill backing panel + hairline; calc(90%-50%e) dieted to static 20.5px). -->
+    <div class="p-hc" style="top:87%;width:70%;height:9%;background:rgba(255,255,255,0.12)"></div>
+    <div class="p-hc" style="top:87%;width:70%;height:2px;background:rgba(255,255,255,0.3)"></div>
+    <div class="p-hc sp-vertical-center" style="top:calc(90% - 20.5px);">
+      <span class="sp-b-s f-num"><eval input="/Dev/Time/LocalTime" outputFormat="script x => ('0'+Math.floor((x/3600)%24)).slice(-2)+':'+('0'+Math.floor((x/60)%60)).slice(-2)" default="--:--" /></span>
+      <span class="f-ico" style="padding-left:6px;padding-right:6px">&#xF100;</span>
+      <span class="sp-b-s f-num"><eval input="/Activity/Move/-1/Duration/Current" outputFormat="Duration_FourdigitsFixed" default="0:00" /></span>
+    </div>
+
+    <!-- Physical pushButtons — universal events, main.js dispatches by state (here state 6 → evProjSetup).
+         up-long = evL(5) save & back to READY; down-long = evL(6) next project slot. evL never laps here
+         (lapState=4: the (n===6&&s===0)||s===1 lap-trigger is false), matching the old shared manage block.
+         'next'/ev(4) is a no-op in proj-setup (evProjSetup has no eid4 branch) — kept for button-map parity. -->
+    <:if test="{{ HAS_ON_EVENT }}">
+    <userInput>
+      <pushButton name="up" type="lock" longType="lock"
+        onClick="ev(1)"
+        onLongPressStart="evL(5)"
+        onLongPressFull=";" />
+      <pushButton name="next" longType="lock"
+        onLongPressStart="ev(4)" />
+      <pushButton name="down" type="lock" longType="lock"
+        onClick="ev(2)"
+        onLongPressStart="evL(6)"
+        onLongPressFull=";" />
+    </userInput>
+    </:if>
+
+  </div>
+</uiView>

--- a/tools/tests/dispatcher-budget.js
+++ b/tools/tests/dispatcher-budget.js
@@ -1,0 +1,41 @@
+// Dispatcher size budget: the build merges ALL lifecycle functions (onLoad/evaluate/onEvent/
+// onExerciseEnd/...) into ONE dispatcher function whose bytecode must fit a single ~4KB
+// compile-time allocation on the watch. Discovered 12.06 15:49: at 1927B minified source the
+// zapp died AT LOAD (`JSalloc:4192 oversize` ×11 → `Compiling js failed` → disabled, watch shows
+// the "max app" warning); at 1874B it compiled. Budget: keep the dispatcher's minified source
+// under 1800B — move logic into top-level function expressions (own compile units) instead.
+// This runs the REAL build (same as the deploy path) and measures the shipped blob.
+'use strict';
+const { execSync } = require('child_process');
+const fs = require('fs');
+const zlibPath = '/tmp/dispatcher-budget-build';
+const APP = __dirname + '/../..';
+const BUDGET = 1875;  // 1874 = proven-loading max (31c14fd era); keep NEW code <1800
+
+const toolsBin = execSync(
+  'ls -d /home/skyfi/.vscode/extensions/suunto.suuntoplus-editor-*/node_modules/@suunto-internal/suuntoplus-tools/bin/build-app.js | sort -V | tail -1'
+).toString().trim();
+execSync(`node ${toolsBin} --appID climbl01 --input ${APP} --output ${zlibPath}`, { stdio: 'pipe' });
+
+// .fea is a stored zip; pull main.js out without unzip deps
+const buf = fs.readFileSync(zlibPath + '/climbl01-q.fea');
+const marker = Buffer.from('main.js');
+let idx = -1, start = -1;
+while ((idx = buf.indexOf(marker, idx + 1)) !== -1) {
+  // local file header: filename directly follows the 30-byte header; compressed size at offset -12
+  const hdr = idx - 30;
+  if (hdr >= 0 && buf.readUInt32LE(hdr) === 0x04034b50) {
+    const size = buf.readUInt32LE(hdr + 18);
+    start = idx + marker.length;
+    var blob = buf.slice(start, start + size).toString();
+    break;
+  }
+}
+if (!blob) { console.error('FAIL: could not extract main.js from the built .fea'); process.exit(1); }
+
+const i = blob.lastIndexOf('return function');
+const dispatcher = blob.length - i;
+const ok = i > 0 && dispatcher < BUDGET;
+console.log(`main.js=${blob.length}B  dispatcher=${dispatcher}B  budget=${BUDGET}B  (fail line ~1927, last-good 1874)`);
+console.log(ok ? 'GREEN — dispatcher within budget' : 'RED — dispatcher over budget: the blob will fail to COMPILE on-watch (JSalloc oversize at Load script). Move code out of lifecycle functions into top-level function expressions.');
+process.exit(ok ? 0 : 1);


### PR DESCRIPTION
## Why
The 2026-06-26 35-route on-watch log (clean, no crash) showed the **project-save screen switch** (manage→active remount) tip `exec:ui` and shed **Movement** at `00:59:16` — harmless ~19 s before the stop, but the *same* remount earlier in a session would drop a co-app for the rest of it, and **3 apps are mandatory**. `manage.html` held **both** SETUP (`sc4`) and proj-setup (`sc6`), so the resident template at project-save was the full **10.3 KB / 16-measure-pass** tree.

## What
Split `sc6` into a dedicated `projsetup.html`; `goState` maps **state 6 → `"projsetup"`** (state 4 → `manage`).

| | resident at project-save | measure-passes |
|---|---|---|
| before | `manage.xml` 10.3 KB (sc4+sc6) | 16 |
| after | **`projsetup.xml` 6.4 KB** (sc6 only) | **1** |

- Combined remount peak **31.8 KB → 27.9 KB**; resident per-mount layout work **−94 %** (16→1 passes) at the exact moment that shed Movement.
- **Zero new swaps:** states 4 and 6 are independent — `goState(4)` does not exist (SETUP is first-launch-only); proj-setup is entered from READY via `eid5` directly, never toggled against SETUP. Same swap pattern as the proven `limit.html` / `edit.html` splits.

`projsetup.html` is a lean single-screen template: no `applyVis`/`vState` (mounted only in state 6), no `SN`/`sN` system-name table (SETUP-only). Vertical `calc(Y%−50%e)` measure-passes converted to static px per the `active.html` diet. `manage.html` is now SETUP-only.

## Verification
- ✅ `build-app.js` Build successful · ✅ deploy-grade `validate.js` = true · ✅ output-lint OK · ✅ dispatcher-budget **1741 B** < 1875 B
- ✅ `onEvent` dispatches by **state** (`6 → evProjSetup`) — unchanged; grade taps / save buttons / output bindings copied byte-for-byte
- ✅ Independent adversarial review (7 checks a–g) found **no behavioral divergence**
- Recovered `tools/tests/dispatcher-budget.js` from history (CLAUDE.md requires it after `main.js` edits; partially addresses #146)

## Notes
- Stacked on #144 (`perf/measure-pass-diet-save-survival`); rebases onto its base when #144 merges.
- `climbl01-q.fea` intentionally **not** committed — rebuild in VS Code before flashing.
- **On-watch test:** enter project-setup and **save a project mid-session at high route count**, ideally while a co-app is under pressure — verify Movement is no longer shed (or sheds later than before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)