### PR TITLE
fix: review findings — grade-system stats corruption (#148) + 4 lower-severity fixes

### DIFF
--- a/main.js
+++ b/main.js
@@ -306,6 +306,7 @@ var saveAsProject = function(output) {
 };
 
 var recalcBse = function() {
+  if (routesEvicted) return;  // #152: arrays incomplete after the 50-route splice — keep the prior best rather than regressing it (mirrors rescanBest; only ever fires at ROUTE_LIMIT>50)
   bestSendIdx = -1;
   for (var i = 0; i < routesA.length; i++) {
     if (rSend(i) && rGrade(i) > bestSendIdx) bestSendIdx = rGrade(i);
@@ -445,6 +446,17 @@ var evSetup = function(output, eid, dy) {
     gradeSystem = (gradeSystem + dy + 10) % 10;
     currentGrade = DEFAULT_IDX[gradeSystem];
     loadProjects(gradeSystem);
+    // #148: reload allTimeStats for the NEW system — the in-memory mirror of ext17's LS snapshot swap.
+    // ext12 loads allTimeStats for the START system at onLoad and it's otherwise never refreshed, so without
+    // this, end-of-session writeStats() (ext11) would persist the OLD system's lifetime counters as the new
+    // system's (s{newSys}), corrupting per-system history. SETUP (state 4) is first-launch-only and
+    // unreachable after any climb, so the switch always precedes route logging — no session data is lost.
+    var sStat = LS.getObject("s" + gradeSystem) || {};
+    allTimeStats.totalRoutes = sStat.totalRoutes || 0;
+    allTimeStats.totalSends = sStat.totalSends || 0;
+    allTimeStats.sendPct = sStat.sendPct || 0;
+    allTimeStats.totalHeight = sStat.totalHeight || 0;
+    allTimeStats.sessions = (sStat.sessions || 0) + 1;  // this session counts toward whichever system it ends in
     gradeV = encGrade(DEFAULT_IDX[gradeSystem]); wGL(output);
     output.modeSub = gradeSystem;
     wsDirty = 1;   // watchSetup needs persisting at session end
@@ -581,8 +593,10 @@ function evaluate(input, output) {
       hrSum += h; hrCnt++;
       if (h > hrMax) hrMax = h;
       hr1Sum += h; hr3Sum += h;
-      if (hrIdx >= 60) { hr1Sum -= hrBuf[(hrIdx - 60) % 180]; if (hr1Sum / 60 > bestPk1) bestPk1 = hr1Sum / 60; }
-      if (hrIdx >= 180) { hr3Sum -= hrBuf[hrIdx % 180]; if (hr3Sum / 180 > bestPk3) bestPk3 = hr3Sum / 180; }
+      // #149: check from the FIRST full window (hrIdx 59 / 179), not 60 / 180 — the initial 60s/180s window
+      // was being skipped (at hrIdx 59 hr1Sum already holds samples 0..59). Subtract only PAST the boundary.
+      if (hrIdx >= 59) { if (hrIdx >= 60) hr1Sum -= hrBuf[(hrIdx - 60) % 180]; if (hr1Sum / 60 > bestPk1) bestPk1 = hr1Sum / 60; }
+      if (hrIdx >= 179) { if (hrIdx >= 180) hr3Sum -= hrBuf[hrIdx % 180]; if (hr3Sum / 180 > bestPk3) bestPk3 = hr3Sum / 180; }
       hrBuf[hrIdx % 180] = h;
       hrIdx++;
     }
@@ -687,7 +701,9 @@ function getSummaryOutputs(input, output) {
   // ERR WBMAIN ... ui Wait). Grade names are now baked into the cache by ext19's dG, so the recap
   // is a pure LS read — zero parse, zero added residency (caching at onLoad tipped the exec:ui
   // mount ceiling — see no-midsession-flash-writes).
-  return LS.getObject("lastSummary") || [{ id: 'sr', name: 'Sends / Routes', format: 'Count_Fourdigits', value: 0, postfix: '/ 0' }];
+  // #150: gate on routesA>0 so an empty (or all-deleted) session shows 0/0, not a PRIOR session's stale
+  // cached recap (an empty session never wrote lastSummary, so the cache is the last non-empty one).
+  return (routesA.length > 0 && LS.getObject("lastSummary")) || [{ id: 'sr', name: 'Sends / Routes', format: 'Count_Fourdigits', value: 0, postfix: '/ 0' }];
 }
 
 function onLap(_input, output) {

--- a/manage.html
+++ b/manage.html
@@ -10,8 +10,6 @@
           function applyVis(x){
             lapState=x;
             setStyle('#sc4','visibility',x===4?'VISIBLE':'HIDDEN');
-            setStyle('#sc5','visibility',x===5?'VISIBLE':'HIDDEN');
-            setStyle('#sc6','visibility',x===6?'VISIBLE':'HIDDEN');
           }
           function ev(n){$.put('/Zapp/{zapp_index}/Event',n,null,'int32')}
           function lap(){$.put('/Activity/Trigger',23)}

--- a/tools/tests/pack-decode-consistency.js
+++ b/tools/tests/pack-decode-consistency.js
@@ -1,0 +1,56 @@
+// Packed-output decode-literal consistency check (#151).
+//
+// Several outputs are packed composites (packedGL, packedBreak, packedPk) plus the route-record packs
+// (routesA/routesB via packA/packB), decoded by BARE LITERAL divisors inside template <eval> formatters and
+// ext19. There is no language-level link between an encoder base in main.js and the decoders — a re-pack that
+// bumps a base in main.js but misses one template <eval> shows WRONG values on-watch while the build still
+// passes (output NAMES are unchanged). That is the worst bug class for this project (on-watch-only).
+//
+// This derives every base from main.js (the single source of truth) and asserts each decode site uses it.
+// Run after any change to wGL/wBrk/wPk/packA/packB or to a template <eval> that decodes one of these outputs.
+'use strict';
+const fs = require('fs');
+const read = (f) => fs.readFileSync(__dirname + '/../../' + f, 'utf8');
+const main = read('main.js');
+
+function base(re, label) {
+  const m = main.match(re);
+  if (!m) { console.error('FAIL: could not extract encoder base for ' + label + ' from main.js (' + re + ')'); process.exit(1); }
+  return m[1];
+}
+
+// Encoder bases — single source of truth = main.js (wGL / wBrk / wPk / packA / packB).
+const GL   = base(/packedGL\s*=\s*gradeV\s*\*\s*(\d+)/, 'packedGL grade');
+const BSE  = base(/packedBreak\s*=\s*\(bse\s*\+\s*1\)\s*\*\s*(\d+)/, 'packedBreak bestSend');
+const CNT  = base(/Math\.min\(63,\s*brkSendsV\)\)\s*\*\s*(\d+)/, 'packedBreak count');
+const PK   = base(/packedPk\s*=\s*a\s*\*\s*(\d+)/, 'packedPk');
+const RA_G = base(/return g\s*\*\s*(1e\d)/, 'packA grade');
+const RA_S = base(/\*\s*1e\d\s*\+\s*s\s*\*\s*(1e\d)/, 'packA send');
+const RA_H = base(/\+\s*c\s*\*\s*(1e\d)/, 'packA cm/height');
+const RB_D = base(/\)\s*\*\s*(\d+)\s*\+\s*\(hr/, 'packB dur');
+
+// Each decode site must contain the matching literal derived from the encoder above.
+const expect = {
+  'active.html':    ['/' + GL, '%' + GL, '/' + BSE, '/' + CNT, '%' + CNT, '/' + PK, '%' + PK],
+  'manage.html':    ['/' + GL],
+  'projsetup.html': ['/' + GL],
+  'edit.html':      ['%' + GL],
+  'ext19.js':       ['/' + RA_G, '/' + RA_S, '%' + RA_H, '/' + RB_D, '%' + RB_D],
+};
+
+const fail = [];
+for (const f in expect) {
+  const src = read(f);
+  for (const lit of expect[f]) {
+    if (src.indexOf(lit) === -1) {
+      fail.push(f + ': expected decode literal "' + lit + '" not found — encoder base changed in main.js but this site was not updated in lockstep?');
+    }
+  }
+}
+
+if (fail.length) {
+  console.error('RED — PACK/DECODE MISMATCH:\n  ' + fail.join('\n  '));
+  process.exit(1);
+}
+console.log('GREEN — pack/decode literals consistent (GL=' + GL + ' BSE=' + BSE + ' CNT=' + CNT + ' PK=' + PK +
+  ' routeA=' + RA_G + '/' + RA_S + '/' + RA_H + ' routeB=' + RB_D + ') across ' + Object.keys(expect).join(', '));


### PR DESCRIPTION
Implements all verified findings from the two code reviews (workflow xhigh + Codex gpt-5.5 whole-codebase) as one PR. Stacked on #147 so it does not disturb the stability test running on the current build.

## Fixes
| Issue | Sev | Fix |
|-------|-----|-----|
| #148 | 🔴 HIGH | `evSetup` reloads `allTimeStats` from `s{newSys}` on a grade-system change (in-memory mirror of ext17's LS snapshot swap). Without it, end-of-session `writeStats`/ext11 persisted the **old** system's lifetime counters as the **new** system's `s{N}`, corrupting per-system history — fired even with **zero routes** (the empty-session bail is defeated by `pendF17`/`wsDirty`). SETUP is first-launch-only and unreachable after a climb, so the reload loses no session data; the session is credited to the system it ends in (`sessions+1`). |
| #149 | 🟡 LOW | `evaluate` checks the HR-peak window from the **first full window** (`hrIdx>=59/179`), subtracting only past the boundary. The initial 60s/180s window was skipped → under-reported `routePk1`/`routePk3` (FIT) + the BREAK `1'`/`3'` display. |
| #152 | 🟡 LOW | `recalcBse` bails on `routesEvicted` (mirrors `rescanBest`) so the best-send isn't regressed from incomplete arrays. Only reachable at `ROUTE_LIMIT>50`. |
| #150 | 🟡 LOW | `getSummaryOutputs` gates on `routesA.length>0` → an empty / all-deleted session shows `0/0` instead of a prior session's stale cached recap. |
| #151 | 🟢 enh | New `tools/tests/pack-decode-consistency.js`: derives the pack bases from `main.js` (single source of truth) and asserts every template/ext19 decode literal matches — a re-pack that misses an `<eval>` now fails CI instead of silently showing wrong values on-watch. |
| — | cleanup | `manage.html` `applyVis` drops the dead `#sc5`/`#sc6` `setStyle` lines (those screens moved to `edit.html`/`projsetup.html`; manage is SETUP-only). |

## Verification (all green)
- ✅ `build-app.js` · ✅ deploy `validate.js`=true · ✅ output-lint · ✅ **dispatcher 1776 B** < 1875
- ✅ new **pack-decode-consistency** GREEN · ✅ **output-pack-equiv** / **route-pack-equiv** ALL PASS
- ✅ **lap-phase-repro** ALL PASS at `ROUTE_LIMIT=35` (the 999 failures are the known temp-cap artifact, proven independent of these changes)
- ✅ Independent adversarial review of all 5 fixes + cleanup — **no logic bugs** (traced #148's sessions-crediting, ext17→ext11 interaction, first-launch, `sendPct`; #149's window boundaries; #150's gate; #152's bail direction)

## Notes
- `ROUTE_LIMIT` stays **999** (stack-wide temp probe; reverts to 35 before merge).
- `climbl01-q.fea` intentionally **not** committed — rebuild in VS Code before flashing.
- **On-watch validation for #148:** switch grade systems → climb → end → reopen, confirm **both** systems' stats are intact.

Closes #148, #149, #150, #151, #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)