### PR TITLE
perf: split READY into ready.html — activity split (lighter startup + edit-entry swap)

### DIFF
--- a/active.html
+++ b/active.html
@@ -8,7 +8,6 @@
           function applyVis(x){
             if(x===lapState)return;
             lapState=x;
-            setStyle('#sc0','visibility',x===0?'VISIBLE':'HIDDEN');
             setStyle('#sc1','visibility',x===1?'VISIBLE':'HIDDEN');
             setStyle('#sc2','visibility',x===2?'VISIBLE':'HIDDEN');
           }
@@ -21,54 +20,14 @@
   <div id="climblogger">
 
 
-    <!-- vState → applyVis: <eval> binding replaces leaky $.subscribe (#90). Eval bindings are framework-managed, do not leak on template unload. -->
-    <!-- SuuntoPlus CSS parser rejects display:none → use visibility:HIDDEN + 0-dim instead. -->
+    <!-- vState → applyVis: <eval> binding toggles sc1 (CLIMB) / sc2 (BREAK). READY (sc0) was split out to
+         ready.html, so active.html now mounts only for CLIMB/BREAK (states 1/2). Eval binding is
+         framework-managed (no $.subscribe leak, #90). CSS parser rejects display:none → visibility:HIDDEN. -->
     <div style="position:absolute;top:0;left:0;width:0;height:0;visibility:HIDDEN"><eval input="/Zapp/{zapp_index}/Output/vState" outputFormat="script x => (applyVis(x),'')" default="" /></div>
 
-    <div id="sc0" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:VISIBLE">
-
-      <div onTap="ev(1)" style="top:17%;left:0;width:70%;height:22%;position:absolute;"></div>
-      <!-- icon centerings use a fixed 18.5px (= half f-ico's 37px line-height) instead of 50%e,
-           so the firmware skips a per-element self-measure (proportionOfElement) at mount.
-           Identical pixels; verified against the compiled active.xml. Text rows keep 50%e
-           (their height isn't a single fixed glyph). -->
-      <div class="f-ico p-hc" style="top:calc(36% - 18.5px);">&#xF266;</div>
-
-      <div class="sp-t-l" style="top:calc(48% - 36.5px); left:calc(50% - 50%e);">
-        <eval input="/Zapp/{zapp_index}/Output/packedGL" outputFormat="script x => dG(Math.floor(x/952))" default="--" />
-      </div>
-
-      <div onTap="ev(2)" style="top:57%;left:0;width:70%;height:25%;position:absolute;"></div>
-      <div class="f-ico p-hc" style="top:calc(66% - 18.5px);">&#xF267;</div>
-
-      <div style="top:18%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
-        <div class="f-ico cm-bgc" style="top:calc(50% - 18.5px); left:6px;">&#xE338;</div>
-      </div>
-      <div onTap="evX(5)" style="top:11%;left:70%;width:30%;height:25%;position:absolute;"></div>
-
-      <div style="top:44%;left:90%;width:10%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
-        <div class="f-ico cm-bgc" style="top:calc(50% - 18.5px); left:6px;">&#xF111;</div>
-      </div>
-      <div onTap="ev(4)" style="top:37%;left:70%;width:30%;height:25%;position:absolute;"></div>
-
-      <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
-        <div class="f-ico cm-bgc" style="top:calc(50% - 18.5px); left:6px;">&#xE373;</div>
-      </div>
-      <div onTap="evL(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
-
-      <!-- Project stats — visible only in project mode (climbMode>0). actT/actS/actB
-           are -1 in non-project mode → script formats return '' to hide. Migrated from
-           setText to output bindings because sc0 is HIDDEN when goState(0) runs from
-           the event handler — setText on hidden elements is a silent no-op. -->
-      <div class="p-hc sp-vertical-center" style="top:calc(78% - 20.5px);">
-        <span class="sp-b-s"><eval input="/Zapp/{zapp_index}/Output/actT" outputFormat="script x => x < 0 ? '' : x + 'T'" default="" /></span>
-        <span class="sp-b-s" style="padding-left:6px"><eval input="/Zapp/{zapp_index}/Output/actS" outputFormat="script x => x < 0 ? '' : x + 'S'" default="" /></span>
-        <span class="sp-b-s" style="padding-left:6px"><eval input="/Zapp/{zapp_index}/Output/actB" outputFormat="script x => x <= 0 ? '' : Math.floor(x/60) + ':' + ('0'+(x%60)).slice(-2)" default="" /></span>
-      </div>
-
-    </div>
-
-    <div id="sc1" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:HIDDEN">
+    <!-- sc1 default-VISIBLE: active.html mounts fresh only on READY→CLIMB (goState(1)); CLIMB↔BREAK after
+         that is an in-template applyVis toggle. So CLIMB is the correct screen to show before vState fires. -->
+    <div id="sc1" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:VISIBLE">
 
       <div class="sp-d-l p-hc" style="top:calc(30% - 50%e);">
         <eval input="/Activity/Lap/-1/Duration/Current" outputFormat="Duration_FourdigitsFixed" default="0:00" />

--- a/main.js
+++ b/main.js
@@ -88,7 +88,7 @@ function getUserInterface() {
   // before or after onLoad (a returning user must open on active, not blank-out on manage). EDIT is never
   // the first screen (reached only from READY), so first resolve is only ever active/manage.
   // After first resolve, goState() owns currentTemplate.
-  if (!currentTemplate) currentTemplate = initReady() ? "active" : "manage";
+  if (!currentTemplate) currentTemplate = initReady() ? "ready" : "manage";  // returning user → READY (ready.html); first-run → SETUP (manage.html)
   return { template: currentTemplate };
 }
 
@@ -246,7 +246,7 @@ var pushEdit = function() {
 
 var goState = function(s, output) {
   state = s;
-  var t = s < 3 ? "active" : s === 3 ? "limit" : s === 5 ? "edit" : s === 6 ? "projsetup" : "manage";  // 0/1/2 → active, 3 → limit.html, 5 → edit.html, 6 → projsetup.html (in-session project config), 4 → manage.html (SETUP, first-launch only). sc6 split out of manage shrinks the project-save remount peak (resident sc4+sc6 → sc4 alone); no new swap since 4/6 are independent (never toggled against each other).
+  var t = s === 0 ? "ready" : s < 3 ? "active" : s === 3 ? "limit" : s === 5 ? "edit" : s === 6 ? "projsetup" : "manage";  // 0 → ready.html, 1/2 (CLIMB/BREAK) → active.html, 3 → limit.html, 5 → edit.html, 6 → projsetup.html, 4 → manage.html (SETUP). READY split out of active: EDIT/proj-setup are entered FROM READY, so a light resident ready.html makes that entry swap small; CLIMB↔BREAK stays an in-active applyVis toggle (no swap); READY↔CLIMB is the only new swap (infrequent — bout start/end).
   var tChanged = (currentTemplate !== t);
   currentTemplate = t;
   if (tChanged) unload('_cm');

--- a/manifest.json
+++ b/manifest.json
@@ -132,6 +132,17 @@
         "q",
         "s"
       ]
+    },
+    {
+      "name": "ready.html",
+      "displays": [
+        "l",
+        "m",
+        "n",
+        "o",
+        "q",
+        "s"
+      ]
     }
   ],
   "variables": [

--- a/ready.html
+++ b/ready.html
@@ -1,0 +1,95 @@
+<!-- READY screen (state 0), split out of active.html. READY is the screen you're ON when you enter EDIT
+     (free mode) or proj-setup (project mode) via the up-long button — so making it its own LIGHT template
+     turns that entry swap into ready(small)+edit/projsetup(small) instead of dragging the full
+     active.html (READY+CLIMB+BREAK) tree resident. CLIMB(sc1)+BREAK(sc2) stay together in active.html, so
+     the FREQUENT CLIMB<->BREAK transition remains a cheap visibility toggle (no swap). The new READY<->CLIMB
+     swap is infrequent (bout start/end, per the lap phase model CLIMB->BREAK->CLIMB skips READY). Single
+     screen: no applyVis/vState binding; lapState hardcoded 0 so evL(6) fires the start lap. -->
+<uiView onFlickUp="ev(7)"
+        onFlickDown="ev(8)"
+        onLoad="
+          var G='3a,3a+,3b,3b+,3c,3c+,4a,4a+,4b,4b+,4c,4c+,5a,5a+,5b,5b+,5c,5c+,6a,6a+,6b,6b+,6c,6c+,7a,7a+,7b,7b+,7c,7c+,8a,8a+,8b,8b+,8c,8c+,9a,9a+,9b,9b+,9c|4,4+,5-,5,5+,6-,6,6+,7-,7,7+,8-,8,8+,9-,9,9+,10-,10,10+,11-,11,11+,12-|5.5,5.6,5.7,5.8,5.9,5.10a,5.10b,5.10c,5.10d,5.11a,5.11b,5.11c,5.11d,5.12a,5.12b,5.12c,5.12d,5.13a,5.13b,5.13c,5.13d,5.14a,5.14b,5.14c,5.14d,5.15a,5.15b,5.15c,5.15d|4a,4b,4c,5a,5b,5c,6a,6b,6c,7a,7b|VB,V0,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12|4A,4A+,4B,4B+,4C,4C+,5A,5A+,5B,5B+,5C,5C+,6A,6A+,6B,6B+,6C,6C+,7A,7A+,7B,7B+,7C,7C+,8A,8A+,8B,8B+,8C,8C+|WI2,WI3,WI3+,WI4,WI4+,WI5,WI5+,WI6,WI6+,WI7,WI7+|M1,M2,M3,M4,M5,M6,M7,M8,M9,M10,M11,M12|Set|Lap'.split('|');
+          var Gs=null,Gsi=-1;
+          function dG(x){if(x<0)return'--';if(x%100>=50)return'OFF';var si=Math.floor(x/100);if(si!==Gsi){Gs=(G[si]||'').split(',');Gsi=si}return(Gs||[])[x%100]||'?'}
+          var lapState=0,lock=0;
+          function ev(n){$.put('/Zapp/{zapp_index}/Event',n,null,'int32')}
+          function lap(){$.put('/Activity/Trigger',23)}
+          function ulk(){lock=0}
+          function evX(n){if(lock)return;ev(n);lock=1;setTimeout(ulk,300)}
+          function evL(n){if(lock)return;var s=lapState;if((n===6&&s===0)||s===1)lap();ev(n);lock=1;setTimeout(ulk,300)}
+        ">
+  <div id="climblogger">
+
+    <div id="sc0" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:VISIBLE">
+
+      <div onTap="ev(1)" style="top:17%;left:0;width:70%;height:22%;position:absolute;"></div>
+      <div class="f-ico p-hc" style="top:calc(36% - 18.5px);">&#xF266;</div>
+
+      <div class="sp-t-l" style="top:calc(48% - 36.5px); left:calc(50% - 50%e);">
+        <eval input="/Zapp/{zapp_index}/Output/packedGL" outputFormat="script x => dG(Math.floor(x/952))" default="--" />
+      </div>
+
+      <div onTap="ev(2)" style="top:57%;left:0;width:70%;height:25%;position:absolute;"></div>
+      <div class="f-ico p-hc" style="top:calc(66% - 18.5px);">&#xF267;</div>
+
+      <div style="top:18%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
+        <div class="f-ico cm-bgc" style="top:calc(50% - 18.5px); left:6px;">&#xE338;</div>
+      </div>
+      <div onTap="evX(5)" style="top:11%;left:70%;width:30%;height:25%;position:absolute;"></div>
+
+      <div style="top:44%;left:90%;width:10%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
+        <div class="f-ico cm-bgc" style="top:calc(50% - 18.5px); left:6px;">&#xF111;</div>
+      </div>
+      <div onTap="ev(4)" style="top:37%;left:70%;width:30%;height:25%;position:absolute;"></div>
+
+      <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
+        <div class="f-ico cm-bgc" style="top:calc(50% - 18.5px); left:6px;">&#xE373;</div>
+      </div>
+      <div onTap="evL(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
+
+      <!-- Project stats — visible only in project mode (climbMode>0). actT/actS/actB are -1 in non-project
+           mode -> script formats return '' to hide. Output bindings (this screen mounts already showing sc0). -->
+      <div class="p-hc sp-vertical-center" style="top:calc(78% - 20.5px);">
+        <span class="sp-b-s"><eval input="/Zapp/{zapp_index}/Output/actT" outputFormat="script x => x < 0 ? '' : x + 'T'" default="" /></span>
+        <span class="sp-b-s" style="padding-left:6px"><eval input="/Zapp/{zapp_index}/Output/actS" outputFormat="script x => x < 0 ? '' : x + 'S'" default="" /></span>
+        <span class="sp-b-s" style="padding-left:6px"><eval input="/Zapp/{zapp_index}/Output/actB" outputFormat="script x => x <= 0 ? '' : Math.floor(x/60) + ':' + ('0'+(x%60)).slice(-2)" default="" /></span>
+      </div>
+
+    </div>
+
+    <!-- Shared ROUTE/PROJECT header band. -->
+    <div class="cm-fg" style="width:100%;height:16%">
+      <div class="sp-t-s p-hc" style="top:calc(50% - 19px);">
+        <eval input="/Zapp/{zapp_index}/Output/modeSub" outputFormat="script x => x > 0 ? 'ROUTE ' + x : 'PROJECT ' + Math.abs(x)" default="ROUTE 1" />
+      </div>
+    </div>
+
+    <!-- Bottom time-bar (shared flat-fill backing panel + hairline). -->
+    <div class="p-hc" style="top:87%;width:70%;height:9%;background:rgba(255,255,255,0.12)"></div>
+    <div class="p-hc" style="top:87%;width:70%;height:2px;background:rgba(255,255,255,0.3)"></div>
+    <div class="p-hc sp-vertical-center" style="top:calc(90% - 20.5px);">
+      <span class="sp-b-s f-num"><eval input="/Dev/Time/LocalTime" outputFormat="script x => ('0'+Math.floor((x/3600)%24)).slice(-2)+':'+('0'+Math.floor((x/60)%60)).slice(-2)" default="--:--" /></span>
+      <span class="f-ico" style="padding-left:6px;padding-right:6px">&#xF100;</span>
+      <span class="sp-b-s f-num"><eval input="/Activity/Move/-1/Duration/Current" outputFormat="Duration_FourdigitsFixed" default="0:00" /></span>
+    </div>
+
+    <!-- Physical pushButtons — universal events, main.js dispatches by state (here state 0 -> evReady).
+         up-long evL(5) = enter EDIT/proj-setup (no lap, lapState=0); down-long evL(6) = start climb (fires
+         the start lap since lapState=0); next-long ev(4) = toggle project/free mode. -->
+    <:if test="{{ HAS_ON_EVENT }}">
+    <userInput>
+      <pushButton name="up" type="lock" longType="lock"
+        onClick="ev(1)"
+        onLongPressStart="evL(5)"
+        onLongPressFull=";" />
+      <pushButton name="next" longType="lock"
+        onLongPressStart="ev(4)" />
+      <pushButton name="down" type="lock" longType="lock"
+        onClick="ev(2)"
+        onLongPressStart="evL(6)"
+        onLongPressFull=";" />
+    </userInput>
+    </:if>
+
+  </div>
+</uiView>


### PR DESCRIPTION
The **activity split** — companion to the **management split** (#147, projsetup). Together they form the "both splits" version, **isolated from the #153 review fixes** (which grow main.js and tip the 3-app startup heap — kept separate to fix without resident-bytecode growth).

## Why
On-watch 2026-06-26 **13:40** a heavier build crashed **hard at startup** — `JSalloc:80 → relMemCb(exec:ui) → None avail` as all 3 apps loaded. The 3-app startup mount sits at the exec:ui/exec:zapp ceiling. This split attacks it from the mount side.

## What
READY (sc0) moves out of `active.html` into its own `ready.html`; `active.html` now holds only CLIMB (sc1) + BREAK (sc2). `goState`: state 0 → `ready`, 1/2 → `active`; `getUserInterface` first-resolve → `ready`.

**Two wins:**
- **Startup:** returning user mounts `ready.xml` **8.2 KB** instead of `active.xml` 21.5 KB — ~13 KB lighter first mount (pure headroom against the startup ceiling).
- **EDIT/proj-setup entry** (the swap that shed Movement at 13:23): entered *from* READY, so resident is now ready.html → entry swap **27.9→14.6 KB** (proj-setup) / **29.7→16.4 KB** (EDIT), far below the ~28 KB that evicted.

CLIMB↔BREAK stays a cheap in-`active` `applyVis` toggle (no swap). The only new swap is **READY↔CLIMB** — infrequent (bout start/end; CLIMB→BREAK→CLIMB skips READY) and at bout-start when pressure is lowest. `active.xml` 21.5→16.8 KB also lightens the inter-app swipe.

`ready.html` is single-screen (no applyVis/vState), `lapState=0` so `evL(6)` fires the start lap.

## Verification
- ✅ build · validate=true · output-lint · **dispatcher 1740 B** (< the crashing build's 1776) · equiv tests
- ✅ independent adversarial review: sc0 reproduced **byte-identical**, all transitions clean, no behavioral divergence
- ✅ confirmed the **#153 review fixes are NOT on this branch** (`#148/#149/#150/#152` grep to 0) — main.js back to ~#147 size

## Notes
- Stacked on #147; the two splits merge as the mount-diet line. The **#153 fixes stay their own PR** to re-implement without growing main.js (the suspected startup-crash cause).
- `ROUTE_LIMIT` stays 999 (→35 before merge); rebuild `climbl01-q.fea` in VS Code before flashing.
- **On-watch test:** this should *start* cleaner than the 13:14 build (lighter first mount) and not evict on project-edit entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)