### PR TITLE
perf: measure-pass diet on manage/edit (−31%/−27% mount cost-U, zero-pixel)

### DIFF
--- a/edit.html
+++ b/edit.html
@@ -12,6 +12,13 @@
         ">
   <div id="climblogger">
 
+    <!-- Fixed-px vertical centerings (top:calc(Y% - Npx)) below replace the costly 50%e self-measure pass.
+         N = half the element's line-height — valid because each is a FIXED-height element on the Vertical 2
+         ('q') display: f-ico 37px->18.5, sp-t-l grade 73px->36.5, time-bar (sp-b-s/f-ico row) 41px->20.5.
+         Source of truth = active.html (same constants, on-watch-proven). CAVEATS: these are 'q'-display-
+         specific (other manifest displays would need their own) and the 20.5 is CONTENT-specific (a larger
+         time-bar child must revert to 50%e). Variable-width / wrapping rows keep left:..50%e. -->
+
     <!-- Dedicated EDIT screen (state 5) — single always-visible section; no applyVis/section-switching. -->
     <div id="sc5" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:VISIBLE">
 

--- a/edit.html
+++ b/edit.html
@@ -25,14 +25,14 @@
       </div>
 
       <div onTap="ev(1)" style="top:17%;left:0;width:70%;height:22%;position:absolute;"></div>
-      <div id="ed-arrUp" class="f-ico p-hc" style="top:calc(36% - 50%e);">&#xF266;</div>
+      <div id="ed-arrUp" class="f-ico p-hc" style="top:calc(36% - 18.5px);">&#xF266;</div>
 
-      <div class="sp-t-l" style="top:calc(48% - 50%e); left:calc(50% - 50%e);">
+      <div class="sp-t-l" style="top:calc(48% - 36.5px); left:calc(50% - 50%e);">
         <eval input="/Zapp/{zapp_index}/Output/packedGL" outputFormat="script x => dG(x%952-1)" default="--" />
       </div>
 
       <div onTap="ev(2)" style="top:57%;left:0;width:70%;height:25%;position:absolute;"></div>
-      <div id="ed-arrDn" class="f-ico p-hc" style="top:calc(66% - 50%e);">&#xF267;</div>
+      <div id="ed-arrDn" class="f-ico p-hc" style="top:calc(66% - 18.5px);">&#xF267;</div>
 
       <div class="p-hc sp-vertical-center" style="top:calc(78% - 50%e);">
         <span id="ed-sendIcon" class="f-ico" style="padding-right:6px">?</span>
@@ -40,18 +40,18 @@
       </div>
 
       <div style="top:18%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
-        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE365;</div>
+        <div class="f-ico cm-bgc" style="top:calc(50% - 18.5px); left:6px;">&#xE365;</div>
       </div>
       <div onTap="evX(5)" style="top:11%;left:70%;width:30%;height:25%;position:absolute;"></div>
 
       <div style="top:44%;left:90%;width:10%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
-        <div id="ed-pillIcon" class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xF107;</div>
+        <div id="ed-pillIcon" class="f-ico cm-bgc" style="top:calc(50% - 18.5px); left:6px;">&#xF107;</div>
         <div id="ed-pillDel" class="sp-b-s cm-bgc" style="top:calc(50% - 50%e); left:2px;visibility:HIDDEN">DEL</div>
       </div>
       <div onTap="ev(4)" style="top:37%;left:70%;width:30%;height:25%;position:absolute;"></div>
 
       <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
-        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE373;</div>
+        <div class="f-ico cm-bgc" style="top:calc(50% - 18.5px); left:6px;">&#xE373;</div>
       </div>
       <div onTap="ev(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
 
@@ -60,7 +60,7 @@
     <!-- Bottom time-bar with a cheap flat-fill backing panel + top hairline (the old clip-path diamond was removed — masks are expensive, plain rgba rects are not). -->
     <div class="p-hc" style="top:87%;width:70%;height:9%;background:rgba(255,255,255,0.12)"></div>
     <div class="p-hc" style="top:87%;width:70%;height:2px;background:rgba(255,255,255,0.3)"></div>
-    <div class="sp-vertical-center" style="left:calc(50% - 50%e); top:calc(91.5% - 50%e);">
+    <div class="sp-vertical-center" style="left:calc(50% - 50%e); top:calc(91.5% - 20.5px);">
       <span class="sp-b-s f-num"><eval input="/Dev/Time/LocalTime" outputFormat="script x => ('0'+Math.floor((x/3600)%24)).slice(-2)+':'+('0'+Math.floor((x/60)%60)).slice(-2)" default="--:--" /></span>
       <span class="f-ico" style="padding-left:6px;padding-right:6px">&#xF100;</span>
       <span class="sp-b-s f-num"><eval input="/Activity/Move/-1/Duration/Current" outputFormat="Duration_FourdigitsFixed" default="0:00" /></span>

--- a/manage.html
+++ b/manage.html
@@ -21,6 +21,13 @@
         ">
   <div id="climblogger">
 
+    <!-- Fixed-px vertical centerings (top:calc(Y% - Npx)) below replace the costly 50%e self-measure pass.
+         N = half the element's line-height — valid because each is a FIXED-height element on the Vertical 2
+         ('q') display: f-ico 37px->18.5, sp-t-l grade 73px->36.5, time-bar (sp-b-s/f-ico row) 41px->20.5.
+         Source of truth = active.html (same constants, on-watch-proven). CAVEATS: these are 'q'-display-
+         specific (other manifest displays would need their own) and the 20.5 is CONTENT-specific (a larger
+         time-bar child must revert to 50%e). Variable-width / wrapping rows keep left:..50%e. -->
+
 
     <!-- vState → applyVis: <eval> binding replaces leaky $.subscribe (#90). Eval bindings are framework-managed, do not leak on template unload. -->
     <!-- SuuntoPlus CSS parser rejects display:none → use visibility:HIDDEN + 0-dim instead. -->

--- a/manage.html
+++ b/manage.html
@@ -28,24 +28,24 @@
 
     <div id="sc4" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:VISIBLE">
 
-      <div class="f-ico p-hc" style="top:calc(22% - 50%e);">&#xF102;</div>
+      <div class="f-ico p-hc" style="top:calc(22% - 18.5px);">&#xF102;</div>
 
       <div onTap="ev(1)" style="top:17%;left:0;width:70%;height:22%;position:absolute;"></div>
-      <div class="f-ico p-hc" style="top:calc(33% - 50%e);">&#xF266;</div>
+      <div class="f-ico p-hc" style="top:calc(33% - 18.5px);">&#xF266;</div>
 
       <div class="sp-t-l" style="top:calc(42% - 50%e); left:calc(50% - 50%e);">
         <eval input="/Zapp/{zapp_index}/Output/modeSub" outputFormat="script x => sN(x)" default="?" />
       </div>
-      <div class="sp-t-l" style="top:calc(59% - 50%e); left:calc(50% - 50%e);">
+      <div class="sp-t-l" style="top:calc(59% - 36.5px); left:calc(50% - 50%e);">
         <eval input="/Zapp/{zapp_index}/Output/packedGL" outputFormat="script x => dG(Math.floor(x/952))" default="--" />
       </div>
 
       <div onTap="ev(2)" style="top:57%;left:0;width:70%;height:25%;position:absolute;"></div>
-      <div class="f-ico p-hc" style="top:calc(74% - 50%e);">&#xF267;</div>
+      <div class="f-ico p-hc" style="top:calc(74% - 18.5px);">&#xF267;</div>
 
       <!-- Bottom pill (save) — DOWN-long = save&exit on setup -->
       <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
-        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE373;</div>
+        <div class="f-ico cm-bgc" style="top:calc(50% - 18.5px); left:6px;">&#xE373;</div>
       </div>
       <div onTap="evX(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
 
@@ -62,24 +62,24 @@
       </div>
 
       <div onTap="ev(1)" style="top:17%;left:0;width:70%;height:22%;position:absolute;"></div>
-      <div class="f-ico p-hc" style="top:calc(36% - 50%e);">&#xF266;</div>
+      <div class="f-ico p-hc" style="top:calc(36% - 18.5px);">&#xF266;</div>
 
-      <div class="sp-t-l" style="top:calc(48% - 50%e); left:calc(50% - 50%e);">
+      <div class="sp-t-l" style="top:calc(48% - 36.5px); left:calc(50% - 50%e);">
         <eval input="/Zapp/{zapp_index}/Output/packedGL" outputFormat="script x => dG(Math.floor(x/952))" default="OFF" />
       </div>
 
       <div onTap="ev(2)" style="top:57%;left:0;width:70%;height:25%;position:absolute;"></div>
-      <div class="f-ico p-hc" style="top:calc(66% - 50%e);">&#xF267;</div>
+      <div class="f-ico p-hc" style="top:calc(66% - 18.5px);">&#xF267;</div>
 
       <!-- Top pill (save & back to ready) — UP-long = save & back -->
       <div style="top:18%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
-        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE365;</div>
+        <div class="f-ico cm-bgc" style="top:calc(50% - 18.5px); left:6px;">&#xE365;</div>
       </div>
       <div onTap="evX(5)" style="top:11%;left:70%;width:30%;height:25%;position:absolute;"></div>
 
       <!-- Bottom pill (save & next slot) — DOWN-long = save & weiter -->
       <div style="top:70%;left:83%;width:15%;height:12%;position:absolute;background:rgba(255,255,255,0.15);">
-        <div class="f-ico cm-bgc" style="top:calc(50% - 50%e); left:6px;">&#xE373;</div>
+        <div class="f-ico cm-bgc" style="top:calc(50% - 18.5px); left:6px;">&#xE373;</div>
       </div>
       <div onTap="ev(6)" style="top:63%;left:70%;width:30%;height:25%;position:absolute;"></div>
 
@@ -88,7 +88,7 @@
     <!-- Bottom time-bar with a cheap flat-fill backing panel + top hairline (the old clip-path diamond was removed — masks are expensive, plain rgba rects are not). -->
     <div class="p-hc" style="top:87%;width:70%;height:9%;background:rgba(255,255,255,0.12)"></div>
     <div class="p-hc" style="top:87%;width:70%;height:2px;background:rgba(255,255,255,0.3)"></div>
-    <div class="sp-vertical-center" style="left:calc(50% - 50%e); top:calc(91.5% - 50%e);">
+    <div class="sp-vertical-center" style="left:calc(50% - 50%e); top:calc(91.5% - 20.5px);">
       <span class="sp-b-s f-num"><eval input="/Dev/Time/LocalTime" outputFormat="script x => ('0'+Math.floor((x/3600)%24)).slice(-2)+':'+('0'+Math.floor((x/60)%60)).slice(-2)" default="--:--" /></span>
       <span class="f-ico" style="padding-left:6px;padding-right:6px">&#xF100;</span>
       <span class="sp-b-s f-num"><eval input="/Activity/Move/-1/Duration/Current" outputFormat="Duration_FourdigitsFixed" default="0:00" /></span>


### PR DESCRIPTION
## What
Converts **18 vertical self-measure centerings** (`calc(Y% - 50%e)` = a `proportionOfElement` layout pass at mount) to fixed-pixel offsets in `manage.html` (11) and `edit.html` (7), reusing the constants `active.html` already proves on-watch:

| class | line-height | substitute |
|---|---|---|
| `f-ico` (single glyph) | 37 px | `18.5px` |
| `sp-t-l` (short grade) | 73 px | `36.5px` |
| time-bar `sp-vertical-center` | 41 px | `20.5px` |

## Why
`manage.html` is the **project-setup mount** (state 6, reached via an `active→manage` template swap) — a confirmed evict moment ([crash-template-swap-eviction], reproduced on-watch 2026-06-30 while editing projects). `edit.html` is the EDIT-entry mount, also a known swap-transient crash point. Removing self-measure passes lightens these mounts on the exec:ui axis.

## Effect (measured via `zappsim execui`)
| template | measure-passes | cost-U | bytes |
|---|---|---|---|
| `manage.xml` | 17 → **6** | 143 → **99 (−31%)** | 10400 → 10092 |
| `edit.xml` | 12 → **5** | 104 → **76 (−27%)** | 8371 → 8175 |
| `active.xml` / `main.js` | — | unchanged | **byte-identical** |

## Safety — zero pixel/feature change, triple-verified
1. Same constants/classes `active.html` already ships on-watch (byte-pattern-identical).
2. Objective compiled-diff: `proportionOfElement` count drops by exactly 18, nothing else changes.
3. Independent adversarial audit confirmed all 18 + caught a trap I'd have missed (`manage.html` system-name `sp-t-l` *wraps* → variable height → kept on `%e`).

KEPT every horizontal `left:calc(X% - 50%e)` (variable text width) and every wrapping/big-font row.

**Deferred (not byte-proven):** `edit.html` header `sp-vertical-center`→`19px` — confirm visually on first flash.

## Full zappsim sweep
`validate` identical (15 paths, WB-load 31), `run` heap identical (no main.js change), `budget` RAW Σtpl.xml −504 B. Aggregate exec:ui peak unchanged (active.xml-bound, correctly untouched) — the win is localized to the manage/edit mounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)