### PR TITLE
feat: alten BREAK-Screen zurück — Sends/Routes + Best-Send-Tally (packedBreak)

### DIFF
--- a/active.html
+++ b/active.html
@@ -30,7 +30,10 @@
     <!-- CLIMB — climb time + pulse, big and uncluttered. Grade lives in the colored header; height/avg/max are BREAK-only. -->
     <div id="sc1" style="position:absolute;top:0;left:0;width:100%;height:100%;visibility:VISIBLE">
 
-      <div class="sp-d-l p-hc" style="top:calc(36% - 50%e);">
+      <!-- Duration anchored at BREAK's 30% (NOT 36%): CLIMB<->BREAK must not shift the big timer.
+           The HR row was already unified to BREAK's 53% and the H-row to 73%; the timer was the last
+           un-aligned element, so it jumped 6% on every lap. sc1/sc2 now share the identical geometry. -->
+      <div class="sp-d-l p-hc" style="top:calc(30% - 50%e);">
         <eval input="/Activity/Lap/-1/Duration/Current" outputFormat="Duration_FourdigitsFixed" default="0:00" />
       </div>
 

--- a/active.html
+++ b/active.html
@@ -61,6 +61,19 @@
         <eval input="/Activity/Lap/-2/Duration/Current" outputFormat="Duration_FourdigitsFixed" default="0:00" />
       </div>
 
+      <!-- BREAK tally RESTORED (old break screen, feat/restore-break-screen): session sends/routes +
+           best-send grade. packedBreak decode in LOCKSTEP with main.js setOutputs (state-2 pack) and
+           tools/tests/output-pack-equiv.js: sends = floor(x/64)%64, routes = x%64, best = dG(floor(x/4096)-1).
+           Trophy F200 labels the best send; dG is defined in this template's onLoad. Only sc2 subscribes
+           packedBreak, so it rides the BREAK-visible mount only. -->
+      <div class="p-hc sp-vertical-center" style="top:calc(64% - 20.5px);">
+        <span class="f-ico" style="padding-right:6px">&#xF200;</span>
+        <span class="sp-b-s" style="padding-right:14px"><eval input="/Zapp/{zapp_index}/Output/packedBreak" outputFormat="script x => dG(Math.floor(x/4096)-1)" default="--" /></span>
+        <span class="sp-b-s f-num"><eval input="/Zapp/{zapp_index}/Output/packedBreak" outputFormat="script x => ''+(Math.floor(x/64)%64)" default="0" /></span>
+        <span class="sp-b-s f-num">/</span>
+        <span class="sp-b-s f-num"><eval input="/Zapp/{zapp_index}/Output/packedBreak" outputFormat="script x => ''+(x%64)" default="0" /></span>
+      </div>
+
       <div class="p-hc sp-vertical-center" style="top:calc(73% - 20.5px);">
         <span class="sp-b-s" style="padding-right:3px">H</span>
         <span class="sp-b-s f-num" style="padding-right:14px"><eval input="/Zapp/{zapp_index}/Output/routeHeight" outputFormat="script x => (x>=0?'+':'')+x+'m'" default="0m" /></span>

--- a/main.js
+++ b/main.js
@@ -186,7 +186,10 @@ var chg = function(k, v) { if (pubF || pubC[k] !== v) { pubC[k] = v; return 1; }
 var lockF = 0;
 var wGL = function(o) { var v = lockF * 1e6 + gradeV * 952 + (lastGradeV + 1); if (chg(3, v)) o.packedGL = v; };
 var wMode = function(o, v) { if (chg(4, v)) o.modeSub = v; };
-// packedBreak (BREAK sends/routes + best-send tally) removed -> moved to end summary (Sends/Routes + Highest Send). Frees 1 WB path off active.html's mount/swap-transient + the per-tick pack. bestSendIdx kept (ext10 needs it).
+// packedBreak RESTORED (old BREAK screen, feat/restore-break-screen): BREAK sends/routes + best-send
+// tally, packed in setOutputs' state-2 branch (see there). COST NOTE: re-adds 1 WB output path to
+// active.html's mount/swap-transient — the exact thing the e8cb57b diet removed; on-watch test whether
+// it revives the setup->ready / app-swipe evict class now that the diet stages freed headroom.
 // 1'/3' rolling peak-HR feature removed (hrBuf ring + packedPk/routePk1/routePk3) — heap diet.
 
 var pushMode = function(o) {
@@ -235,6 +238,17 @@ var setOutputs = function(output) {
     pAct = routesA.length === 0 ? -5 : editDelMark ? -4 : rSend(editIdx) ? -2 : -3;
   }
   if (chg(5, pAct)) output.packedAct = pAct;
+  // packedBreak (RESTORED for the old BREAK screen): session sends/routes + best-send tally, packed
+  // into ONE output for the BREAK row. (bestSend+1)*4096 + sat(sends)*64 + sat(routes), counts clamp
+  // at 63 (display degrades, composite stays valid; ROUTE_LIMIT 35). Written only in BREAK (state 2);
+  // 0 elsewhere (the row lives on sc2 only). DECODE LOCKSTEP: active.html sc2 + output-pack-equiv.js.
+  var pBrk = 0;
+  if (state === 2) {
+    var bse = bestSendIdx >= 0 ? encGrade(bestSendIdx) : -1, snd = 0, bi;
+    for (bi = 0; bi < routesA.length; bi++) if (rSend(bi)) snd++;
+    pBrk = (bse + 1) * 4096 + Math.min(63, snd) * 64 + Math.min(63, routesA.length);
+  }
+  if (chg(8, pBrk)) output.packedBreak = pBrk;
   var hg = state === 1 ? gradeV : state === 2 ? lastGradeV : -1;  // header grade: current (CLIMB) / sent (BREAK) / blank (READY — its body shows it big)
   if (chg(6, hg)) output.hdrGrade = hg;
   var hres = state === 2 ? (lastResult ? 1 : 2) : 0;  // header colour: 1=green(sent) / 2=orange(fail) on BREAK, set by the CLIMB-finish result; 0=neutral elsewhere

--- a/manifest.json
+++ b/manifest.json
@@ -39,6 +39,9 @@
     },
     {
       "name": "packedAct"
+    },
+    {
+      "name": "packedBreak"
     }
   ],
   "template": [


### PR DESCRIPTION
## Summary
Holt die Zeile zurück, die `e8cb57b` für die Eviction-Diät entfernt hatte: Der **BREAK-Screen zeigt wieder den Session-Fortschritt** — Sends/Routes-Zähler + Best-Send-Grade (Trophäe), neben der bestehenden Höhe/HR-Zeile.

Auf der aktuellen (space-capsule) Architektur neu implementiert — die alte e8cb57b-main.js existiert so nicht mehr:
- **manifest.json:** `packedBreak`-Output zurück.
- **main.js:** Pack im state-2-Zweig von setOutputs — `(bestSend+1)*4096 + sat(sends)*64 + sat(routes)`, Zähler klemmen bei 63, float32-exakt (<2^24); nur in BREAK geschrieben, sonst 0. **+147 B resident** (7496→7643 B).
- **active.html sc2:** die Tally-Zeile (Trophäe F200 + Best-Grade + Sends/Routes); Decode im Lockstep mit `output-pack-equiv.js` — der Test hatte die packedBreak-Encode/Decode-Runde die ganze Zeit behalten.

## ⚠️ Kosten-Notiz (der Grund, warum es damals raus musste)
- **active.xml-Mount: 11821 → 12749 B** (+928 B)
- **+1 WB-Output-Pfad** auf active.html's Mount/Swap-Transient — genau der Hebel der Setup→Ready- / App-Swipe-Eviction.

Das ist der Trade, den du on-watch testen wolltest: Haben die Diät-Stufen (kleineres main.js + kleinerer Store) genug Luft geschaffen, um diese Zeile wieder zu tragen? Basis ist master (Stufe 1+2); Stufe 3 (#184) ist hier NICHT drin.

## Test Plan
- [x] Build successful; validateFile true; output-lint clean; alle 7 Harnesses grün (packedBreak-Round-Trip im output-pack-equiv intakt)
- [x] Kompilierte active.xml enthält die 3 packedBreak-Bindings + F200-Trophäe
- [ ] **On-Watch (User):** (1) BREAK-Screen zeigt Sends/Routes + Best-Grade korrekt (mehrere Routen mit Sends/Fails loggen, im BREAK prüfen); (2) **der eigentliche Test:** rapide App-Swipes rein/raus + Setup→Ready-Wechsel — evictet der größere active-Mount wieder die Co-Apps (Weather/Movement blinken), oder trägt die freigewordene Luft die Zeile?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DysFaFuh3SZ2BR1ZXh71C5