### PR TITLE
feat(shell8-S2): Sturm-Wächter — Retry-Caps an allen Parse/LS-Pfaden

### DIFF
--- a/main.js
+++ b/main.js
@@ -57,6 +57,15 @@ var sessionsNo = 1;
 // path is LS-free; the END does the RMW directly via ext11 (see finishSession). The eP/WAL
 // variant (pause write + next-enable replay) was FALSIFIED on-watch 2026-07-03 — do not re-add.
 var pendF12 = 1;   // bootstrap pending: 1 = attempt on the next tick, >1 = backoff countdown after a failed attempt. Normally cleared INSIDE onLoad (inline drain, no evalFile); the tick path is the OOM fallback only.
+// S2 storm caps: every retrying parse/LS path gets a hard attempt bound — on a corpse heap each
+// attempt costs a RelMem burst, and an unbounded retry loop IS the storm (the P4 stg() loop
+// re-attempted every 3s for 13 minutes; a cable pulse did not stop it). After the cap the app
+// runs DEGRADED but alive: defaults + open guards instead of a self-inflicted allocation storm.
+var dfTries = 0;   // drainF12 attempts (cap 3) — then defaults stay, guards open, stOk stays 0
+var stOk = 0;      // 1 = bootstrap drain succeeded. 0 at end = READ-ONLY session: never ext11-RMW a
+                   // store we never read (grow-rewrite/clobber landmine) — skip the save, show NOT SAVED.
+var slTries = 0;   // post-switch fillSlots attempts (cap 3) — then climbMode=0: START must never stay silently refused
+var exFail = 0;    // ext10 parse/call failures (cap 3) — then routes commit DEGRADED inline (no slot stats)
 var psDirty = 0;   // projSlot changed this session       -> ext11 dirty bit 0 (writes pS<gs>)
 var slotsDirty = 0;// projGradeIdx changed on the WATCH   -> ext11 dirty bit 1 (writes stats.p<gs>_* + purge; ungated it would clobber Companion slot edits made between sessions)
 var sysDirty = 0;  // grade system changed (persist even on a routeless session)
@@ -119,16 +128,17 @@ var fillSlots = function(sv, sys) {
 // LOCKSTEP oracle: tools/tests/drain-inline-equiv.js proves equivalence with the deleted ext12.js.
 var skipP = 0;  // returning-user SETUP->READY auto-skip, armed by the drain, fired on the next tick, cancelled by any button press
 var drainF12 = function(autoSkip) {
+  dfTries++;  // count the ATTEMPT (before anything that can throw) — cap enforced at the call sites
   var L = localStorage, sv = L.getObject("stats") || {}, i;
   // stats.rou0 = genuine rou-format legacy data -> COLD ext13 migration (rare), then re-read.
   if (sv.rou0 !== undefined) { try { loadExt(13)(); sv = L.getObject("stats") || {}; } catch (e) {} }
-  gradeSystem = sv.system >= 0 && sv.system <= 9 ? sv.system | 0 : 0;
+  if (!sysDirty) gradeSystem = sv.system >= 0 && sv.system <= 9 ? sv.system | 0 : 0;  // never clobber an in-session system choice (end-belt drain after a late bootstrap)
   fillSlots(sv, gradeSystem);
   var Z = L.getObject("pS" + gradeSystem);
   if (Z) for (i = 0; i < 20; i++) projSlot[i] = Z[i] !== undefined ? Z[i] : i < 15 ? 0 : -1;
   currentGrade = DEFAULT_IDX[gradeSystem];
   sessionsNo = (sv.sessions | 0) + 1;
-  pendF12 = 0;
+  pendF12 = 0; stOk = 1;
   if (autoSkip && sv.sessions > 0 && sv.showSetupOnStart === 0) skipP = 1;  // ONLY when the companion setting is explicitly 0; default (1/undefined) = ask every start
 };
 
@@ -380,21 +390,38 @@ var commitDirty = function() {
   // no params since the hrMax cut (#171 exts-1): input.M was only read for ext10's dead arg 5.
   // (Historic minifier gotcha `input || {}` is moot without the param — see minifier-bare-input.)
   if (frDirty) {
-    frDirty = 0;
     lastHrAvg = hrCnt > 0 ? hrSum / hrCnt : 0;
     lastDuration = rSec;  // no input.D fallback: a sub-second route (rSec=0) logged a firmware-LAP duration (wrong unit/scope -> ~99999s, displayed 1666:39, poisoned project bestTime). Honest 0:00 instead.
-    var r = (f10 || (f10 = loadExt(10)))(lastGradeIdx, gradeSystem, lastDuration, lastHrAvg, 0,
-      frSend, lastClimbMode, bestSendIdx, projSlot, sessionsNo, lastHeight);  // lazy-parse ext10 on the FIRST route, cached for the session. lastClimbMode (slot at finish), NOT live climbMode. arg 5 (m) is DEAD in ext10 — literal 0 keeps the positional harness (stats-endwrite-equiv) intact; hrMax tracking removed (#171)
-    if (lastClimbMode > 0) psDirty = 1;  // ext10 mutated the slot's stats vector
-    if (!f3) { try { f3 = loadExt(30 + gradeSystem); } catch (e) {} }  // warm the name slice at the proven commit moment (M8) so buildSummary needs no END-window parse (M6)
-    bestSendIdx = r[0];
-    if (r[2]) {
+    var r = 0;
+    if (exFail < 3) {
+      try {
+        r = (f10 || (f10 = loadExt(10)))(lastGradeIdx, gradeSystem, lastDuration, lastHrAvg, 0,
+          frSend, lastClimbMode, bestSendIdx, projSlot, sessionsNo, lastHeight);  // lazy-parse ext10 on the FIRST route, cached for the session. lastClimbMode (slot at finish), NOT live climbMode. arg 5 (m) is DEAD in ext10 — literal 0 keeps the positional harness (stats-endwrite-equiv) intact; hrMax tracking removed (#171)
+      } catch (e) {
+        if (++exFail < 3) return;  // S2 cap: frDirty stays armed -> retried next evaluate tick (bounded, <=3 attempts; worst case ~3s of the BREAK eid4/6 gate). Pre-S2 this path LOST the route silently.
+      }
+    }
+    frDirty = 0;  // cleared only after the parse gauntlet resolved (success or cap) — no BREAK softlock, no silent route loss
+    if (r) {
+      exFail = 0;  // success re-arms the per-route budget: 3 isolated recovered hiccups across a long session must not degrade every later route (a true storm never resets — after 3 straight fails no success ever runs)
+      if (lastClimbMode > 0) psDirty = 1;  // ext10 mutated the slot's stats vector
+      if (!f3) { try { f3 = loadExt(30 + gradeSystem); } catch (e) {} }  // warm the name slice at the proven commit moment (M8) so buildSummary needs no END-window parse (M6). SUCCESS branch only: the degraded path must not add parse attempts on a heap that just refused one (S2 doctrine) — buildSummary falls back to a nameless row.
+      bestSendIdx = r[0];
       var rec = r[2];  // [grade, send, cm, height, dur, hrAvg] transient from ext10 (f10) — packed here, not stored boxed
       routesA.push(packA(rec[0], rec[1], rec[2], rec[3]));
       routesB.push(packB(rec[4], rec[5]));
-      if (routesA.length > 50) { routesA.splice(0, routesA.length - 50); routesB.splice(0, routesB.length - 50); }
-      sessionH += lastHeight || 0;
+    } else {
+      // DEGRADED inline commit (S2, exFail cap): heap too fragmented for the ext10 parse — the route
+      // still lands in the session arrays/summary/best-send tally. The WHOLE slot subsystem is skipped
+      // consistently: no projSlot update, psDirty stays unset, AND cm packs as 0 (free-mode tag) —
+      // a cm>0 tag without the matching attempt/send increments would let a later ext21 op mutate
+      // phantom slot stats and re-arm psDirty for the end-write.
+      if (frSend && lastGradeIdx > bestSendIdx) bestSendIdx = lastGradeIdx;
+      routesA.push(packA(lastGradeIdx, frSend, 0, lastHeight));
+      routesB.push(packB(lastDuration, lastHrAvg));
     }
+    if (routesA.length > 50) { routesA.splice(0, routesA.length - 50); routesB.splice(0, routesB.length - 50); }
+    sessionH += lastHeight || 0;
     hrSum = hrCnt = rSec = 0;
     // packedBreak (brkSends/brkRoutes fields) + actT/actS/actB updated by setOutputs (called at end of evaluate).
   }
@@ -488,7 +515,7 @@ var evSetup = function(output, eid, dy) {
     gradeV = encGrade(DEFAULT_IDX[gradeSystem]); wGL(output);
     wMode(output, gradeSystem);
   } else if (eid === 6) {
-    if (sysChg) { sysChg = 0; pendSlots = 1; }  // slots load one tick AFTER the mount (never AT it); a plain confirm must not clobber in-session slot edits
+    if (sysChg) { sysChg = 0; pendSlots = 1; slTries = 0; }  // slots load one tick AFTER the mount (never AT it); a plain confirm must not clobber in-session slot edits. Fresh switch = fresh retry budget (S2 cap)
     goState(0, output);  // instant, MOUNT-ONLY — no flash write at the switch confirm; the system choice lives in RAM + persists at end via sysDirty. saveSetup deferred to onExerciseEnd.
   }
 };
@@ -526,8 +553,8 @@ function onLoad(_input, output) {
 
 function evaluate(input, output) {
   if (isPaused) return;
-  if (pendF12) { if (pendF12 > 1) pendF12--; else { try { drainF12(1); } catch (e) { pendF12 = 4; } } }  // OOM fallback only (onLoad normally drained already): failed attempts back off 3 ticks — every attempt on a corpse heap costs a RelMem burst (#169)
-  else if (pendSlots) { pendSlots = 0; try { fillSlots(localStorage.getObject("stats") || {}, gradeSystem); } catch (e) { pendSlots = 1; } }  // post-switch slot load, one calm tick after the ready mount; retry next tick on OOM
+  if (pendF12) { if (pendF12 > 1) pendF12--; else if (dfTries < 3) { try { drainF12(1); } catch (e) { pendF12 = 4; } } else pendF12 = 0; }  // OOM fallback only (onLoad normally drained already): failed attempts back off 3 ticks — every attempt on a corpse heap costs a RelMem burst (#169). CAP 3 (S2): then give up — defaults stay live, guards open, stOk stays 0 (read-only session, NOT-SAVED row at end)
+  else if (pendSlots) { pendSlots = 0; try { fillSlots(localStorage.getObject("stats") || {}, gradeSystem); } catch (e) { if (++slTries < 3) pendSlots = 1; else { climbMode = 0; projGradeIdx[0] = projGradeIdx[1] = projGradeIdx[2] = projGradeIdx[3] = projGradeIdx[4] = -1; } } }  // post-switch slot load, one calm tick after the ready mount; retry next tick on OOM. CAP 3 (S2): then free mode AND wipe the slot vector to the unconfigured sentinel — it still holds the DEPARTED system's grade indices (possibly >= GRADE_LENS[new system]); the gate must never open over cross-system slots
   else if (pendE) { var pE = pendE; pendE = 0; try { if (pE === 2) { lastResult = callE(3, routesA.length - 1); } else fE = fE || loadExt(21); } catch (e) { fE = null; } }  // M9 gate drain: parse the satellite (and run a gated quickfix) OUTSIDE the press context; on throw the gate opens and action presses lazy-retry (C11, no timers)
   else if (skipP) { skipP = 0; if (state === 4) goState(0, output); }  // tick 2: returning user -> READY
   if (input.Asc !== undefined) curAsc = input.Asc;
@@ -608,11 +635,21 @@ var endRoute = function() {
 // never nested, every LS access a REWRITE of a drain-seeded key. Stats are in LS the moment the
 // activity saves, so the companion sync right after a session is current.
 var finishSession = function(input) {
-  if (pendF12) { try { drainF12(0); } catch (e) {} }  // belt: an instant start->end session must still bootstrap before persisting
+  if (pendF12 && dfTries < 3) { try { drainF12(0); } catch (e) {} }  // belt: an instant start->end session must still bootstrap before persisting. S2: the belt respects the attempt cap — a 4th RelMem burst in the end window buys nothing the first 3 didn't
   if (state === 1) endRoute();
+  if (frDirty && exFail < 2) exFail = 2;  // S2: the end window gets NO further ticks to re-drive the bounded retry, and the pause already nulled f10 (cold parse guaranteed) — pre-seed the budget so a single throw falls THROUGH to the degraded inline commit instead of returning with the route still armed (silent loss)
   try { commitDirty(); } catch (e) {}
   try { foldRoutes(); } catch (e) {}  // fold any not-yet-folded routes (the whole session if no pause preceded, or just the post-continue ones) + free the arrays + build the RAM summary
   if ((!acc || acc[1] === 0) && !psDirty && !slotsDirty && !sysDirty) return;  // nothing logged/changed -> skip the save burst (acc, not routesA, is the route tally now: routesA may already be folded+freed at pause)
+  if (!stOk) {  // S2 READ-ONLY session: the bootstrap drain never succeeded, so an ext11 RMW would
+    // grow-rewrite a store we never read (clobber + landmine class). Skip the save entirely —
+    // psDirty/slotsDirty/sysDirty never reach ext11 — and say so on the summary instead of losing data silently.
+    try {  // this path only exists on a proven-hostile heap: the row allocation itself may throw — the read-only return must survive it
+      var ns = [{ id: 'ns', name: 'NOT SAVED', format: 'Count_Fourdigits', value: 0 }];
+      lastSummaryCache = lastSummaryCache ? ns.concat(lastSummaryCache).slice(0, 4) : ns;
+    } catch (e) {}
+    return;
+  }
   try { deLoad(); } catch (e) {}
   f10 = null; fE = null; f3 = null;  // buildSummary already ran in foldRoutes above (name read) — release all cached parses before the ext11 RMW / disable
   try {

--- a/tools/tests/storm-caps-equiv.js
+++ b/tools/tests/storm-caps-equiv.js
@@ -1,0 +1,323 @@
+// storm-caps-equiv.js — proves the S2 storm caps: every retrying parse/LS path is attempt-bounded
+// and lands in a defined DEGRADED state instead of a self-inflicted allocation storm (the P4 probe's
+// uncapped stg() re-attempted every 3s for 13 minutes on-watch; a cable pulse did not stop it).
+//
+//   dfTries cap (drainF12) : <=3 attempts total (onLoad + tick fallback + end belt), then defaults
+//                            stay live, guards open, stOk stays 0 -> READ-ONLY session:
+//                            psDirty/slotsDirty/sysDirty never reach ext11, summary shows NOT SAVED.
+//   slTries cap (fillSlots): <=3 post-switch attempts, then climbMode=0 and the input gate opens —
+//                            START must never stay silently refused behind a dead retry gate.
+//   exFail  cap (ext10)    : <=3 parse/call attempts, then routes commit DEGRADED inline (same
+//                            record ext10 returns; only the slot-stats vector update is skipped).
+//                            Pre-S2 a cold-parse throw LOST the route silently.
+//
+// Candidate = the real main.js in a vm sandbox; ext10/ext11/ext21 are the REAL files (loaded from
+// disk) behind an evalFile shim with per-ext throw switches + attempt counters. Healthy-heap case
+// asserts the caps never fire on a good heap (the S2 no-regression claim).
+//
+// Run: node tools/tests/storm-caps-equiv.js   (exit non-zero on any failure)
+
+'use strict';
+var fs = require('fs');
+var vm = require('vm');
+var path = require('path');
+
+var ROOT = path.join(__dirname, '..', '..');
+var MAIN = fs.readFileSync(path.join(ROOT, 'main.js'), 'utf8');
+var EXT_SRC = {};
+
+// ---- shims ------------------------------------------------------------------
+function makeLS(seed) {
+  var store = {};
+  for (var k in seed) store[k] = JSON.parse(JSON.stringify(seed[k]));
+  var ls = {
+    throwing: false,           // flip to make every getObject throw (corpse-heap read)
+    counts: {},                // getObject calls per key
+    sets: 0,                   // setObject calls (the persistence detector)
+    getItem: function () { return null; },
+    setItem: function () {},
+    getObject: function (k) {
+      ls.counts[k] = (ls.counts[k] || 0) + 1;
+      if (ls.throwing) throw new Error('LS OOM');
+      return store[k] === undefined ? null : store[k];
+    },
+    setObject: function (k, v) { ls.sets++; store[k] = v; },
+    _store: store
+  };
+  return ls;
+}
+
+// exts are evaluated INSIDE the vm context so ext11/ext13/ext14 see the shimmed localStorage.
+function makeSandboxVmExts(ls) {
+  var ev = { counts: {}, throwing: {} };
+  var sandbox = {
+    localStorage: ls,
+    setText: function () {}, setStyle: function () {}, unload: function () {},
+    Math: Math, JSON: JSON
+  };
+  sandbox.evalFile = function (p) {
+    var m = /ext(\d+)\.js$/.exec(p);
+    var n = m ? m[1] : p;
+    ev.counts[n] = (ev.counts[n] || 0) + 1;
+    if (ev.throwing[n]) throw new Error('JSalloc');
+    if (!EXT_SRC[n]) EXT_SRC[n] = fs.readFileSync(path.join(ROOT, 'ext' + n + '.js'), 'utf8');
+    return vm.runInContext('(' + EXT_SRC[n] + ')', sandbox, { filename: 'ext' + n + '.js' });
+  };
+  vm.createContext(sandbox);
+  var src = MAIN +
+    '\n;this.__api={onLoad:onLoad,evaluate:evaluate,onEvent:onEvent,onLap:onLap,' +
+    'onExercisePause:onExercisePause,onExerciseContinue:onExerciseContinue,' +
+    'onExerciseEnd:onExerciseEnd,getSummaryOutputs:getSummaryOutputs};' +
+    '\n;this.__st=function(){return {pendF12:pendF12,dfTries:dfTries,stOk:stOk,slTries:slTries,' +
+    'exFail:exFail,pendSlots:pendSlots,climbMode:climbMode,frDirty:frDirty,state:state,' +
+    'routesA:routesA.slice(),routesB:routesB.slice(),bestSendIdx:bestSendIdx,' +
+    'gradeSystem:gradeSystem,acc:acc?acc.slice():null,sum:lastSummaryCache,' +
+    'projGradeIdx:projGradeIdx.slice(),currentGrade:currentGrade,psDirty:psDirty};};';
+  vm.runInContext(src, sandbox, { filename: 'main.js' });
+  sandbox.__ev = ev;
+  return sandbox;
+}
+
+var fails = 0;
+function check(cond, msg) { if (!cond) { console.log('  FAIL  ' + msg); fails++; } }
+function pass(name) { console.log('  PASS  ' + name); }
+
+var RETURNING = { stats: { system: 0, sessions: 7, showSetupOnStart: 0, p0_1: 5, p0_2: -1, p0_3: -1, p0_4: -1, p0_5: -1 } };
+function tick(sb, n, inp) { for (var i = 0; i < (n || 1); i++) sb.__api.evaluate(inp || { H: 1.5, Asc: 10 }, {}); }
+function press(sb, eid) { sb.__api.onEvent({}, {}, eid); }
+function decodeA(a) { return { grade: Math.floor(a / 1e6), send: Math.floor(a / 1e5) % 10, cm: Math.floor(a / 1e4) % 10, h: a % 1e4 }; }
+function hasNs(sum) { if (!sum) return false; for (var i = 0; i < sum.length; i++) if (sum[i].id === 'ns') return true; return false; }
+
+console.log('[storm-caps-equiv] S2 attempt caps + degraded landings vs main.js');
+
+// ---- T1: healthy session — caps never fire, save runs -----------------------
+(function () {
+  var ls = makeLS(RETURNING);
+  var sb = makeSandboxVmExts(ls);
+  sb.__api.onLoad({}, {});
+  tick(sb, 2);                       // skipP -> READY
+  check(sb.__st().state === 0, 'T1: READY after autoskip (state=' + sb.__st().state + ')');
+  press(sb, 6); tick(sb, 3);         // CLIMB, 3s
+  press(sb, 6); tick(sb, 1);         // SEND -> BREAK -> commit tick
+  var st = sb.__st();
+  check(st.routesA.length === 1 && decodeA(st.routesA[0]).send === 1, 'T1: route committed via ext10');
+  check(st.frDirty === 0, 'T1: frDirty cleared');
+  sb.__api.onExercisePause({}, {});
+  sb.__api.onExerciseEnd({}, {});
+  st = sb.__st();
+  check(st.dfTries === 1 && st.stOk === 1 && st.exFail === 0 && st.slTries === 0,
+    'T1: caps untouched on healthy heap (df=' + st.dfTries + ' st=' + st.stOk + ' ex=' + st.exFail + ' sl=' + st.slTries + ')');
+  check(sb.__ev.counts['10'] === 1, 'T1: ext10 parsed exactly once (' + sb.__ev.counts['10'] + ')');
+  check(sb.__ev.counts['11'] === 1, 'T1: ext11 end-save ran (' + sb.__ev.counts['11'] + ')');
+  check(ls.sets > 0, 'T1: persistence happened');
+  check(!hasNs(st.sum), 'T1: no NOT-SAVED row on a healthy save');
+  if (!fails) pass('T1 healthy session — caps never fire');
+})();
+
+// ---- T2: dfTries cap — defaults, open guards, read-only end + NOT SAVED -----
+(function () {
+  var f0 = fails;
+  var ls = makeLS(RETURNING);
+  ls.throwing = true;                // corpse heap from the first read on
+  var sb = makeSandboxVmExts(ls);
+  sb.__api.onLoad({}, {});           // attempt 1 fails
+  check(sb.__st().pendF12 > 1, 'T2: onLoad failure arms backoff');
+  tick(sb, 14);                      // backoff x3 -> attempt2, backoff -> attempt3, backoff -> give up
+  var st = sb.__st();
+  check(ls.counts['stats'] === 3, 'T2: exactly 3 drain attempts (' + ls.counts['stats'] + ')');
+  check(st.pendF12 === 0 && st.dfTries === 3 && st.stOk === 0, 'T2: gave up with open guards (pendF12=' + st.pendF12 + ' dfTries=' + st.dfTries + ' stOk=' + st.stOk + ')');
+  // guards open -> app usable on defaults: SETUP confirm -> READY -> CLIMB -> SEND
+  press(sb, 6);                      // evSetup confirm (no system change -> no pendSlots)
+  check(sb.__st().state === 0, 'T2: SETUP confirm works after cap');
+  press(sb, 6); tick(sb, 2); press(sb, 6); tick(sb, 1);
+  st = sb.__st();
+  check(st.routesA.length === 1, 'T2: route logged on default state');
+  sb.__api.onExercisePause({}, {});
+  sb.__api.onExerciseEnd({}, {});
+  st = sb.__st();
+  check(ls.counts['stats'] === 3, 'T2: end belt respects the cap (attempts=' + ls.counts['stats'] + ')');
+  check(ls.sets === 0, 'T2: READ-ONLY — no setObject ever (' + ls.sets + ')');
+  check(!sb.__ev.counts['11'], 'T2: ext11 never parsed');
+  check(hasNs(st.sum) && st.sum[0].id === 'ns', 'T2: NOT SAVED row leads the summary');
+  check(st.sum.length <= 4, 'T2: summary row cap respected');
+  if (fails === f0) pass('T2 dfTries cap — defaults + read-only end + NOT SAVED');
+})();
+
+// ---- T3: dfTries recovery — attempt 2 succeeds, session saves normally ------
+(function () {
+  var f0 = fails;
+  var ls = makeLS(RETURNING);
+  var throwsLeft = 1;
+  var origGet = ls.getObject;
+  ls.getObject = function (k) {
+    ls.counts[k] = (ls.counts[k] || 0) + 1;
+    if (throwsLeft > 0) { throwsLeft--; throw new Error('LS OOM'); }
+    return ls._store[k] === undefined ? null : ls._store[k];
+  };
+  var sb = makeSandboxVmExts(ls);
+  sb.__api.onLoad({}, {});           // attempt 1 fails
+  tick(sb, 4);                       // backoff 3 ticks -> attempt 2 succeeds
+  var st = sb.__st();
+  check(st.pendF12 === 0 && st.stOk === 1 && st.dfTries === 2, 'T3: recovered on attempt 2 (stOk=' + st.stOk + ' dfTries=' + st.dfTries + ')');
+  tick(sb, 1);                       // skipP fires -> READY
+  press(sb, 6); tick(sb, 2); press(sb, 6); tick(sb, 1);
+  sb.__api.onExerciseEnd({}, {});
+  st = sb.__st();
+  check(sb.__ev.counts['11'] === 1 && ls.sets > 0, 'T3: save ran after recovery');
+  check(!hasNs(st.sum), 'T3: no NOT-SAVED row after recovery');
+  if (fails === f0) pass('T3 dfTries recovery — late drain still saves');
+})();
+
+// ---- T4: slTries cap — post-switch slot load gives up, input gate opens -----
+// Cross-system trap included: system 0 (41 grades) has slot1 at idx 35; the user switches to
+// system 3 (11 grades). The cap MUST wipe projGradeIdx to -1 — otherwise toggleMode re-enters
+// project mode on the departed system's out-of-range grade (the review-confirmed corruption).
+(function () {
+  var f0 = fails;
+  var ls = makeLS({ stats: { system: 0, sessions: 0, showSetupOnStart: 1, p0_1: 35 } }); // fresh user -> stays SETUP
+  var sb = makeSandboxVmExts(ls);
+  sb.__api.onLoad({}, {});
+  check(sb.__st().state === 4, 'T4: fresh user stays in SETUP');
+  check(sb.__st().projGradeIdx[0] === 35, 'T4: boot system slot loaded (idx 35)');
+  press(sb, 1); press(sb, 1); press(sb, 1);  // dy x3: system 0 -> 3 (GRADE_LENS 11), sysChg armed
+  var before = ls.counts['stats'] || 0;
+  ls.throwing = true;                // heap dies before the confirm
+  press(sb, 6);                      // confirm: pendSlots=1, slTries=0, READY mount
+  check(sb.__st().pendSlots === 1, 'T4: pendSlots armed at confirm');
+  press(sb, 6);                      // gated: pendSlots blocks input
+  check(sb.__st().state === 0, 'T4: input gated while pendSlots pending');
+  tick(sb, 5);                       // attempts 1..3, then give-up (ticks 4/5 must not re-attempt)
+  var st = sb.__st();
+  check((ls.counts['stats'] || 0) - before === 3, 'T4: exactly 3 slot-load attempts (' + ((ls.counts['stats'] || 0) - before) + ')');
+  check(st.pendSlots === 0 && st.slTries === 3, 'T4: gate open after cap (pendSlots=' + st.pendSlots + ')');
+  check(st.climbMode === 0, 'T4: free-mode fallback');
+  check(st.projGradeIdx.join() === '-1,-1,-1,-1,-1', 'T4: departed system slot vector WIPED (' + st.projGradeIdx + ')');
+  press(sb, 4);                      // toggleMode: no configured slot -> climbMode 1, no grade copy
+  press(sb, 6);                      // START on unconfigured slot: refused (pre-existing #103 rule)
+  check(sb.__st().state === 0, 'T4: unconfigured-slot START refusal intact');
+  press(sb, 4);                      // back to free mode
+  press(sb, 6);                      // START must work now (free mode, default grade)
+  st = sb.__st();
+  check(st.state === 1, 'T4: START never stays silently refused (state=' + st.state + ')');
+  check(st.currentGrade === 5 && st.currentGrade < 11, 'T4: grade stays in the NEW system range (' + st.currentGrade + ')');
+  ls.throwing = false;               // heal so the end path is exercised cleanly
+  tick(sb, 2); press(sb, 6); tick(sb, 1);
+  var d = decodeA(sb.__st().routesA[0]);
+  check(d.grade === 5 && d.grade < 11, 'T4: committed grade in-range for system 3 (' + d.grade + ')');
+  if (fails === f0) pass('T4 slTries cap — free-mode fallback, wiped slots, open gate');
+})();
+
+// ---- T5: exFail cap — bounded retry, degraded commit, no route loss ---------
+(function () {
+  var f0 = fails;
+  var ls = makeLS(RETURNING);
+  var sb = makeSandboxVmExts(ls);
+  sb.__api.onLoad({}, {});
+  tick(sb, 2); press(sb, 6); tick(sb, 3);   // READY -> CLIMB, 3s at H 1.5
+  sb.__ev.throwing['10'] = true;            // corpse heap: ext10 unparseable
+  press(sb, 6);                             // SEND -> BREAK, frDirty armed
+  tick(sb, 1);
+  check(sb.__st().frDirty === 1 && sb.__st().exFail === 1, 'T5: attempt 1 failed, route still armed');
+  press(sb, 6);                             // BREAK exit gated by frDirty
+  check(sb.__st().state === 2, 'T5: BREAK gate holds during bounded retry');
+  tick(sb, 1);
+  check(sb.__st().frDirty === 1 && sb.__st().exFail === 2, 'T5: attempt 2 failed, still armed');
+  tick(sb, 1);                              // attempt 3 -> cap -> DEGRADED commit
+  var st = sb.__st();
+  check(st.frDirty === 0 && st.exFail === 3, 'T5: cap reached, frDirty cleared (no BREAK softlock)');
+  check(st.routesA.length === 1, 'T5: route NOT lost (degraded commit landed)');
+  var d = decodeA(st.routesA[0]);
+  check(d.send === 1 && d.grade === 18 && d.cm === 0, 'T5: degraded record matches ext10 shape (g=' + d.grade + ' s=' + d.send + ' cm=' + d.cm + ')');
+  check(st.routesB[0] === 3000 + 1.5, 'T5: duration/hr packed (B=' + st.routesB[0] + ')');
+  check(st.bestSendIdx === 18, 'T5: best-send tally maintained inline');
+  check(sb.__ev.counts['10'] === 3, 'T5: exactly 3 parse attempts (' + sb.__ev.counts['10'] + ')');
+  // second route: no further parse attempts, degraded immediately
+  press(sb, 6);                             // BREAK -> READY (frDirty clear now)
+  press(sb, 6); tick(sb, 2); press(sb, 6); tick(sb, 1);
+  st = sb.__st();
+  check(st.routesA.length === 2 && st.frDirty === 0, 'T5: second route lands degraded same tick');
+  check(sb.__ev.counts['10'] === 3, 'T5: no parse storm on later routes (attempts=' + sb.__ev.counts['10'] + ')');
+  // end: healthy save (ext11 parseable, LS fine) — degraded routes persist via the normal fold
+  sb.__api.onExerciseEnd({}, {});
+  st = sb.__st();
+  check(st.acc && st.acc[1] === 2 && st.acc[0] === 2, 'T5: both routes folded into the summary (acc=' + st.acc + ')');
+  check(sb.__ev.counts['11'] === 1 && ls.sets > 0, 'T5: end save ran normally');
+  check(!hasNs(st.sum), 'T5: stOk=1 -> no NOT-SAVED row');
+  if (fails === f0) pass('T5 exFail cap — degraded commit, tally intact, no storm');
+})();
+
+// ---- T5b: END-WINDOW first fail — no ticks left, route must land degraded ---
+// The end commit is ALWAYS a cold parse (onExercisePause nulls f10, the watch always pauses
+// before ending) and finishSession drives commitDirty exactly ONCE. A first-ever ext10 throw
+// there (exFail 0) must fall THROUGH to the degraded commit, not return with the route armed.
+(function () {
+  var f0 = fails;
+  var ls = makeLS(RETURNING);
+  var sb = makeSandboxVmExts(ls);
+  sb.__api.onLoad({}, {});
+  tick(sb, 2); press(sb, 6); tick(sb, 3);
+  press(sb, 6);                              // SEND -> BREAK, frDirty armed, exFail 0
+  sb.__ev.throwing['10'] = true;             // heap turns hostile BEFORE any commit tick runs
+  sb.__api.onExercisePause({}, {});          // pause immediately (same second) — no evaluate tick
+  sb.__api.onExerciseEnd({}, {});
+  var st = sb.__st();
+  check(st.frDirty === 0, 'T5b: route resolved in the end window (frDirty=' + st.frDirty + ')');
+  check(st.acc && st.acc[1] === 1 && st.acc[0] === 1, 'T5b: route folded into summary (acc=' + st.acc + ')');
+  check(st.bestSendIdx === 18, 'T5b: best-send tally maintained');
+  check(sb.__ev.counts['10'] === 1, 'T5b: exactly ONE end-window parse attempt (' + sb.__ev.counts['10'] + ')');
+  check(sb.__ev.counts['11'] === 1 && ls.sets > 0, 'T5b: end save ran with the rescued route');
+  check(!hasNs(st.sum) && st.sum && st.sum[0].value === 1, 'T5b: summary shows 1/1');
+  if (fails === f0) pass('T5b end-window first fail — degraded commit reachable, route saved');
+})();
+
+// ---- T5c: transient failure recovers AND re-arms the budget ------------------
+(function () {
+  var f0 = fails;
+  var ls = makeLS(RETURNING);
+  var sb = makeSandboxVmExts(ls);
+  sb.__api.onLoad({}, {});
+  tick(sb, 2); press(sb, 6); tick(sb, 2);
+  sb.__ev.throwing['10'] = true;
+  press(sb, 6); tick(sb, 1);                 // attempt 1 fails
+  check(sb.__st().exFail === 1 && sb.__st().frDirty === 1, 'T5c: transient fail keeps route armed');
+  sb.__ev.throwing['10'] = false;            // heap recovers
+  tick(sb, 1);                               // attempt 2 succeeds -> normal ext10 commit
+  var st = sb.__st();
+  check(st.routesA.length === 1 && st.frDirty === 0, 'T5c: route committed normally on retry');
+  check(decodeA(st.routesA[0]).cm === 0 && st.exFail === 0, 'T5c: success re-arms the budget (exFail=' + st.exFail + ')');
+  // a later route gets the full budget again — pause/continue in between so f10 goes cold
+  // (the pause nulls the cached parse; a warm f10 would sidestep evalFile entirely)
+  sb.__api.onExercisePause({}, {});          // folds route 1, frees arrays, nulls f10
+  sb.__api.onExerciseContinue({}, {});
+  press(sb, 6); press(sb, 6); tick(sb, 2);   // BREAK -> READY -> CLIMB
+  sb.__ev.throwing['10'] = true;
+  press(sb, 6); tick(sb, 1);                 // cold parse fails once
+  check(sb.__st().exFail === 1 && sb.__st().frDirty === 1, 'T5c: later route retries again (budget re-armed)');
+  sb.__ev.throwing['10'] = false;
+  tick(sb, 1);
+  check(sb.__st().routesA.length === 1 && sb.__st().exFail === 0, 'T5c: second route recovers too (post-fold arrays hold just it)');
+  if (fails === f0) pass('T5c transient recovery — per-route budget, storms still capped');
+})();
+
+// ---- T5d: degraded commit in PROJECT mode never poisons the slot subsystem ---
+(function () {
+  var f0 = fails;
+  var ls = makeLS({ stats: { system: 0, sessions: 7, showSetupOnStart: 0, p0_1: 20 } });
+  var sb = makeSandboxVmExts(ls);
+  sb.__api.onLoad({}, {});
+  tick(sb, 2);
+  press(sb, 4);                              // toggleMode -> project slot 1 (grade 20)
+  check(sb.__st().climbMode === 1 && sb.__st().currentGrade === 20, 'T5d: project mode on slot 1');
+  press(sb, 6); tick(sb, 2);                 // CLIMB on the slot
+  sb.__ev.throwing['10'] = true;
+  press(sb, 6); tick(sb, 3);                 // 3 fails -> degraded commit
+  var st = sb.__st();
+  check(st.frDirty === 0 && st.routesA.length === 1, 'T5d: degraded commit landed');
+  var d = decodeA(st.routesA[0]);
+  check(d.cm === 0, 'T5d: degraded route packs cm=0 — no phantom project tag (cm=' + d.cm + ')');
+  check(st.psDirty === 0, 'T5d: psDirty stays unset (slot stats untouched)');
+  if (fails === f0) pass('T5d degraded project-mode commit — slot subsystem consistently skipped');
+})();
+
+console.log(fails === 0 ? '\nALL PASS' : '\n' + fails + ' FAILURE(S)');
+process.exit(fails === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary
- Harte Versuchsgrenzen an jedem Retry-Pfad (dfTries/slTries/exFail ≤3) — die 13-min-Selbststurm-Klasse (P4-Sonde) ist damit konstruktiv unmöglich
- READ-ONLY-Session + sichtbare NOT-SAVED-Row, wenn der Bootstrap-Drain nie gelang (kein ext11-RMW auf einen ungelesenen Store)
- Degradierter Inline-Commit statt stillem Routenverlust bei kaltem ext10-Parse-Fail (inkl. End-Fenster: exFail-Vorsaat, da finishSession nur 1 Versuch hat und die Pause f10 nullt)
- projGradeIdx-Wipe beim slTries-Cap (Cross-System-Grade-Korruption, Review-Fund)
- Neuer Harness `tools/tests/storm-caps-equiv.js` (8 Fälle; T1 beweist: auf gesundem Heap feuert kein Cap)

16-Agenten-Adversarial-Review: 12 Findings → 4 echte Defekte, alle gefixt. Blob 7182→~7550 B, Dispatcher weit unter dem Compile-Cliff. Kein Toggle-Gewinn — kauft Sicherheit (SHELL-8 Stufe S2).

## Test Plan
- [x] storm-caps-equiv 8/8 + alle 6 Bestands-Harnesses grün
- [x] build-app.js + validateFile + Output-Lint + bare-output-Grep am Blob
- [ ] Watch-Checkpoint: normale Session — Caps feuern auf gesundem Heap nie

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DysFaFuh3SZ2BR1ZXh71C5