### PR TITLE
#191 + #152 — Aktivitäts-Graphen zurück (climbing / height / grade-step), fold-blinder Splice gelöscht (v3.5)

### DIFF
--- a/ext22.js
+++ b/ext22.js
@@ -5,6 +5,10 @@ if(F||pv[1]!==st){o[5]=st;pv[1]=st}
 var lg=S[4]>=0?gs*100+S[4]:-1;
 var rh=st===1?Math.max(0,Math.round(S[13]-S[14])):st===2?S[8]:S[9];
 if(F||pv[2]!==rh){o[4]=rh;pv[2]=rh}
+var cl=st===1?1:0;
+if(F||pv[9]!==cl){o[10]=cl;pv[9]=cl}
+var gl=st===1?S[12]:S[4]>=0?S[4]:S[12];
+if(F||pv[10]!==gl){o[11]=gl;pv[10]=gl}
 if(st===5){g=S[1]<rA.length?gs*100+Math.floor(rA[S[1]]/1e6):gs*100+50;m=S[1]+1;lg=-1}
 else if(st===6){g=P[S[5]]>=0?gs*100+P[S[5]]:gs*100+50;m=-(S[5]+1);lg=-1}
 else if(st===4){g=gs*100+S[17][gs];m=gs;lg=-1}

--- a/main.js
+++ b/main.js
@@ -70,7 +70,7 @@ var slotsDirty = 0;// projGradeIdx changed on the WATCH   -> ext11 dirty bit 1 (
 var sysDirty = 0;  // grade system changed (persist even on a routeless session)
 
 var GRADE_LENS = [41, 24, 29, 11, 14, 30, 11, 12, 1, 1];
-var ROUTE_LIMIT = 35;  // in-session route cap → at the cap, START shows the LIMIT screen (state 3); save+restart resets per-session heap/subscriptions/WB-pool occupancy (a periodic reset valve). packedBreak counts saturate at 63 (exact ≤63 routes, fine ≤35).
+var ROUTE_LIMIT = 35;  // The cap gates on live routesA.length, and foldRoutes() empties routesA at every pause, so the live tail cannot exceed 35 and needs no eviction. Raising this above 50 or removing the pause fold requires re-deriving that invariant. packedBreak counts saturate at 63.
 var DEFAULT_IDX = [18, 6, 5, 5, 4, 12, 3, 5, 0, 0];
 var gradeSystem = 0;
 var loadExt = function(n) { return evalFile('{file_path}/ext' + n + '.js'); };
@@ -345,7 +345,6 @@ var commitDirty = function() {
       routesA.push(packA(lastGradeIdx, frSend, 0, lastHeight));
       routesB.push(Math.min(86399, Math.max(0, Math.round(lastDuration))) * 1000 + (lastHrAvg > 0 ? lastHrAvg : 0));  // packB inlined (S3)
     }
-    if (routesA.length > 50) { routesA.splice(0, routesA.length - 50); routesB.splice(0, routesB.length - 50); }
     sessionH += lastHeight || 0;
     hrSum = hrCnt = rSec = 0;
     // packedBreak (brkSends/brkRoutes fields) + actT/actS/actB updated by setOutputs (called at end of evaluate).

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "name": "Climb Log",
   "description": "Track your progress on rock & ice.",
-  "version": "3.4",
+  "version": "3.5",
   "author": "skyfi",
-  "modificationTime": 1783803487,
+  "modificationTime": 1783803827,
   "type": "feature",
   "usage": "workout",
   "in": [
@@ -26,7 +26,10 @@
       "name": "modeSub"
     },
     {
-      "name": "routeHeight"
+      "name": "routeHeight",
+      "log": true,
+      "shownName": "Route Height",
+      "format": "Ascent_Fourdigits"
     },
     {
       "name": "vState"
@@ -42,6 +45,18 @@
     },
     {
       "name": "packedBreak"
+    },
+    {
+      "name": "climbing",
+      "log": true,
+      "shownName": "Climbing",
+      "format": "Count_Twodigits"
+    },
+    {
+      "name": "gradeLog",
+      "log": true,
+      "shownName": "Grade",
+      "format": "Count_Twodigits"
     }
   ],
   "template": [

--- a/tools/gen-out-idx.js
+++ b/tools/gen-out-idx.js
@@ -29,7 +29,7 @@
 //   12 currentGrade, 13 curAsc, 14 startAsc, 15 projGradeIdx(ref), 16 projSlot(ref),
 //   17 DEFAULT_IDX(ref)
 // pv keys (unchanged from the old chg()): 1 vState, 2 routeHeight, 3 packedGL, 4 modeSub,
-//   5 packedAct, 6 hdrGrade, 7 hdrRes, 8 packedBreak
+//   5 packedAct, 6 hdrGrade, 7 hdrRes, 8 packedBreak, 9 climbing, 10 gradeLog
 // Write order is o-first-then-pv: a mid-call throw can only leave the store NEWER than the
 // cache (rewritten on the next call), never stale-behind-cache.
 
@@ -51,6 +51,16 @@ var TPL = [
   'var lg=S[4]>=0?gs*100+S[4]:-1;',
   'var rh=st===1?Math.max(0,Math.round(S[13]-S[14])):st===2?S[8]:S[9];',
   'if(F||pv[2]!==rh){o[@routeHeight@]=rh;pv[2]=rh}',
+  // Activity graphs (#191): climbing is the on-route binary; gradeLog holds the last route's raw grade
+  // index off-route so the activity reads as a step graph. Before the first route, use the selected grade.
+  // CHANGE-GATED like every other output (pv keys 9/10). A logged output does NOT need re-writing every
+  // tick: the firmware samples the output STORE once a second, and the store retains its last value — so
+  // an unconditional write would just burn 2 extra WB writes per second for no signal. It also broke the
+  // chg-cache invariant that output-map-equiv enforces ("unchanged republish wrote a slot").
+  'var cl=st===1?1:0;',
+  'if(F||pv[9]!==cl){o[@climbing@]=cl;pv[9]=cl}',
+  'var gl=st===1?S[12]:S[4]>=0?S[4]:S[12];',
+  'if(F||pv[10]!==gl){o[@gradeLog@]=gl;pv[10]=gl}',
   'if(st===5){g=S[1]<rA.length?gs*100+Math.floor(rA[S[1]]/1e6):gs*100+50;m=S[1]+1;lg=-1}',
   'else if(st===6){g=P[S[5]]>=0?gs*100+P[S[5]]:gs*100+50;m=-(S[5]+1);lg=-1}',
   'else if(st===4){g=gs*100+S[17][gs];m=gs;lg=-1}',

--- a/tools/tests/output-map-equiv.js
+++ b/tools/tests/output-map-equiv.js
@@ -78,6 +78,11 @@ function refFull(s) {
   }
   o.packedGL = lockF * 1e6 + gradeV * 952 + (lastGradeV + 1);
   o.modeSub = ms;
+  // #191 activity graphs. climbing = the on-route binary. gradeLog HOLDS the last route's raw grade
+  // index while off-route (a step graph, not a sawtooth — `climbing` already carries the on/off signal);
+  // before the first route there is no lastGradeIdx, so the selected grade stands in.
+  o.climbing = s.state === 1 ? 1 : 0;
+  o.gradeLog = s.state === 1 ? s.currentGrade : (s.lastGradeIdx >= 0 ? s.lastGradeIdx : s.currentGrade);
   var pAct = -1;
   if (s.state === 0 && s.climbMode > 0) {
     var i = s.climbMode - 1;
@@ -121,7 +126,11 @@ function bag(s) {
     s.climbMode, s.lastHeight, s.sessionH, s.bestSendIdx, s.lastResult, s.currentGrade, s.curAsc,
     s.startAsc, s.projGradeIdx, s.projSlot, DEFAULT_IDX];
 }
-function freshIO() { var a = []; for (var i = 0; i < 10; i++) a.push(SENT); return a; }
+// Size the io vector FROM THE MANIFEST (in[].length + out[].length), never a hardcoded count.
+// It used to be a literal 10, which silently broke the moment #191 added climbing (slot 10) and
+// gradeLog (slot 11): those indices fell off the end, so ioC[10] read `undefined` instead of the
+// SENT sentinel and every "was this slot written?" check reported a phantom write.
+function freshIO() { var a = []; for (var i = 0; i < OFF + NAMES.length; i++) a.push(SENT); return a; }
 function named(io) { var o = {}; NAMES.forEach(function (n) { o[n] = io[IDX[n]]; }); return o; }
 
 var ext22 = vm.runInNewContext('(' + fs.readFileSync(path.join(BLOB, 'ext22.js'), 'utf8') + ')', { Math: Math });


### PR DESCRIPTION
Closes #191, closes #152.

Implemented by **Codex (GPT-5.6)**; reviewed, corrected and verified here.
**Stacked on [#190](https://github.com/wylandplex/suuntoplus-climb-logger/pull/190)** — base is `feat/issues-187-188-189`, so merge that first.

---

## #191 — the activity graphs are back (3 of them)

Graphs come from a single manifest flag — **`"log": true`** — which streams an output into the recorded activity. **The app had zero.** They were **collateral damage** of `7eab48e` ("heap diet"), which was actually aimed at the *rolling peak-HR* feature (a 180-float ring buffer, ~1.4 KB runtime heap, −618 B bytecode). The graphs themselves cost almost nothing.

| graph | cost |
|---|---|
| **`routeHeight`** | **free** — already an output, already published every tick. Only the `log` flag was missing. Zero computation, zero new WB path. |
| **`climbing`** | the on-route binary (`state === 1 ? 1 : 0`) — restored verbatim from `0bdc486`. |
| **`gradeLog`** | **new** — the grade **step** graph. Holds the last route's raw grade index while off-route, so the activity reads as terraces. It does *not* drop to 0 between routes: `climbing` already carries the on/off signal, and a hold makes the better graph. |

Peak-HR stays buried — that was the expensive thing (see #149).

### Correction to Codex
It wrote `climbing`/`gradeLog` **unconditionally on every publish**, bypassing the `pv` change-cache every other output respects — **2 extra WB writes per second, forever**. A logged output does not need that: the firmware samples the output *store* once a second and the store retains its last value. Now change-gated via `pv[9]`/`pv[10]`. `output-map-equiv` caught this as *"chg cache broken"*.

## #152 — the fold-blind splice is deleted

**The issue's premise was stale**: `routesEvicted` and `rescanBest` no longer exist. The real defect was what remained:

```js
if (routesA.length > 50) { routesA.splice(...); routesB.splice(...) }
```

This discarded routes **without folding them into `acc`**. Since `ef36255`, `acc` is the **session source of truth** (the BREAK tally, the `bestSendIdx` seed, and the end recap all read `acc` + the un-folded tail) — so a splice without a fold would erase those routes from **both** halves. Silent data loss.

Unreachable at ship config (`ROUTE_LIMIT = 35` gates on `routesA.length`, and `foldRoutes()` empties `routesA` at every pause) ⇒ **deleted**, with the invariant documented at the `ROUTE_LIMIT` declaration so nobody re-derives it wrong.

## Test-harness bug found along the way
`output-map-equiv`'s `freshIO()` hardcoded the io-vector length to **10**. The two new outputs (slots 10 and 11) fell off the end, so `ioC[10]` read `undefined` instead of the `SENT` sentinel — producing **phantom writes in every slot check**. Now derived from the manifest (`in[].length + out[].length`); it cannot go stale again.

---

## Budget
| | before | after |
|---|---|---|
| resident blob (`main.js` in `.fea`) | 6982 B | **6919 B (−63)** — the splice |
| `ext22.js` | 1449 B | **1527 B** |
| `main.js` module-level units | — | **unchanged, none added** |

⚠️ **`ext22` is now 73 B under its 1600 B cap.** The next output has to earn its place, or `ext22` needs splitting. Worth knowing before the next feature.

## Verification (run here, not by Codex)
* `Build successful`, deploy validator `true`, `zappsim PASS — 0 fail 0 warn`, `gen-out-idx --check` in sync
* **13/13 equivalence suites green** — re-run after the rebase onto the ring fix, since a rebase can produce a tree neither branch ever tested.

## Open question (deliberately not fixed)
`ROUTE_LIMIT` gates on `routesA.length`, and a pause **empties** `routesA` — so the 35-route cap effectively **resets on every pause** and a session can exceed 35 routes. `packedBreak` saturates its counts at 63; the end recap reads the unsaturated `acc` and stays correct. Since `ROUTE_LIMIT` is also the "periodic reset valve" that bounds heap, this deserves an explicit decision rather than a silent fix.