### PR TITLE
docs: v3.02 across README/CHANGELOG/APPSTORE — END-FOLD reality, limit section, release entries

### DIFF
--- a/APPSTORE.md
+++ b/APPSTORE.md
@@ -6,11 +6,9 @@ Log climbing sessions on the watch: per-route send/fail, projects across 10 grad
 
 ## Updating from 2.82
 
-Your history migrates automatically the first time you finish a session — nothing to export or re-enter. If that save ever fails, the old store is left untouched and the migration is retried on your next finished session.
+Your history migrates automatically the first time you finish a session. If that save ever fails, the old store is left untouched and the migration is retried on your next finished session. 2.82 often failed to save its own stats (see Fixes below), so there may be less history to carry over than you remember — your grade system and configured projects come across; totals and counters that 2.82 never actually wrote can't be recovered and start counting reliably from now on.
 
-One honest caveat: 2.82 often failed to save its own stats (see Fixes below), so there may be less history to carry over than you remember — your grade system and configured projects come across; totals and counters that 2.82 never actually wrote can't be recovered and start counting reliably from now on.
 
-Two buttons moved: **hold UP** now opens the route editor (it used to switch Free/Project mode), and the **Free/Project switch is now a MID long-press**.
 
 ## What changed since 2.82
 
@@ -22,27 +20,29 @@ Two buttons moved: **hold UP** now opens the route editor (it used to switch Fre
 **Controls**
 - Edit any route in the session — grade, SEND/FAIL/DELETE, or move it to another project slot — not just the last one.
 - SETUP only asks for the grade system; the forced 5-project wizard is gone. Projects are set up on demand.
-- The watch lap button now starts a climb, logs a send, or jumps to the next climb.
-- Free-mode flick jumps ±3 grades.
+- The watch lap button now starts a climb or logs a send.
 
 **New**
-- HR-zone ring with a live needle on the READY, ACTIVE and SETUP screens.
-- Live route height (+Nm) shown during both climb and break.
+- Suunto HR-zone ring on all screens.
+- Route height in meters shown during climb and on break-screen
 - MID long-press in BREAK saves the last free-mode route as a new project.
-- Two new grade systems — Hangboard and Scrambling — for 10 in total (up from 8), each keeping its five project slots.
+- Two new grade systems — Hangboard and Scrambling
 - Each grade system now keeps its own separate lifetime stats.
 - The companion dashboard now breaks stats down per grade system.
 - Richer post-activity graphs — height, climb/rest timeline and grade over time, instead of a single route count.
 
 **Fixes**
 - Lifetime totals and project try/send counters now actually save. 2.82 silently lost most of these writes — totals rarely moved and project counters often stayed at 0/0 no matter how much you climbed. Everything is now committed in a single save at session end.
-- Long-pressing a button no longer bounces you out of the app mid-session.
-- Steadier next to other SuuntoPlus apps — leaner memory use and a redesign to survive being toggled on and off mid-workout — though long-session and heavy multi-app freezes aren't fully eliminated yet.
+- Steadier next to other SuuntoPlus apps — leaner memory use and a redesign to survive being toggled on and off mid-workout — though long-session (50+ routes/laps) and pairing with other heavy apps may still cause evictions (apps closing)
 
 **Removed**
 - The running route/send tally on the rest screen — the counts still live in the companion stats, just not on-watch.
 
-Once you pause, routes from before the pause fold into the summary and can no longer be edited.
+## Long sessions: pausing and the 35-route limit
+
+The watch keeps up to **35 routes live** at a time — live routes are the ones you can still open in the editor. **Pausing the workout folds** everything so far into the session summary: all counts and stats are kept, but folded routes can no longer be edited, and all 35 live slots are free again.
+
+If you log 35 routes without a single pause, START (button and lap) simply stops responding — no message — until you pause once. Pause the workout during your longer rests, like you naturally would, and you will never run into the limit.
 
 ## Controls
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## v3.02 — 2026-07-20
+
+- **Legacy store cleanup after migration.** Once the migration fold has verifiably landed
+  (read-back guard: the canonical write is re-read before anything else happens — a silently
+  dropped write can never be followed by legacy erasure), the old 2.82 roots are emptied
+  (`climbRoutes`, `watchSetup`, `stats`) as the last action of the same session end. Permanent
+  store shrink for every migrated user (worst-case fixture: 2 607 → 1 341 B); absent keys are
+  never created; a cleanup failure is silent and the fold still counts. Zero resident cost —
+  the tail lives in the once-per-install `ext11` satellite. (#201)
+
+## v3.01 — 2026-07-20
+
+Same-day field hotfix for the first real 2.82 upgrade on the released store build:
+
+- **2.82 stores without a `stats` root migrated through the wrong converter** — 2.82 only wrote
+  `stats` on rare occasions (see below), so real stores can lack it entirely; the format detector
+  mis-routed them into the numeric converter, stamping an empty v3 container and orphaning the
+  configured projects. Detection is now `typeof stats.system !== "number"` (2.82 = string OR
+  absent), and the converter self-derives the system from `watchSetup.sys`. (#199)
+- **Crash on system switch during a pending migration** — the initial seed used to land on French
+  instead of the user's own system, forcing a switch whose confirm re-parsed the seed satellite
+  right next to the READY mount (exec:ui exhaustion → co-app eviction → firmware assert →
+  reboot). The seed now derives the correct system (no switch needed), and the parse is cached
+  for the whole SETUP dwell, surviving pause/continue. (#199)
+- Root-cause find along the way: **v2.82 dropped most of its own stats writes** — only the first
+  storage write per button event ever landed on-watch, which is why lifetime totals and project
+  counters rarely moved on real 2.82 watches. The single-write END design is the structural fix.
+
+## v3.0 — 2026-07-20
+
+The stability + migration release (public version jumps v2.0 → v3.0; the July architecture line).
+
+- **END-FOLD storage migration**: legacy stores (live 2.82 and numeric dev formats) migrate to
+  the canonical v3 container inside the first finished session — one atomic write, failure-safe,
+  retried on the next END. No migration screen; the session is fully live meanwhile. (#196)
+- **Resource diet**: resident `main.js` cut 7 351 → 6 894 B, 28 → 23 module units, no feature
+  cuts — the currency that decides 3-app heap survival. Dual-reviewed (multi-agent + Codex). (#197)
+- **Suunto HR-zone ring** with a live needle on every screen. Header turns green/orange on
+  send/fail. Per-system lifetime stats (10 grade systems incl. new Hangboard + Scrambling),
+  companion dashboard broken down per system, richer post-activity graphs (height, climb/rest
+  timeline, grade over time).
+- Route editor for the whole live session (grade, SEND/FAIL/DELETE, move between project slots);
+  lap-button integration (start climb / log send); pause folds routes into the summary
+  (35-route live cap, freed at every pause).
+
+
 ## v2.0 — 2026-07-13
 
 **Version-scheme note:** the manifest `version` field bumps on every watch-test build (project

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Climb Log v3.0
+# Climb Log v3.02
 
-[![Latest](https://img.shields.io/badge/release-v3.0-blue)](https://github.com/wylandplex/suuntoplus-climb-logger)
+[![Latest](https://img.shields.io/badge/release-v3.02-blue)](https://github.com/wylandplex/suuntoplus-climb-logger)
 
 A SuuntoPlus app for logging climbing sessions on Suunto watches. Tracks routes across 10 grade systems, 5 project slots per system (50 total), heart rate, height gain, and multi-year grade progression.
 
@@ -54,8 +54,9 @@ until a new editable tail route exists.
 - Touch tap-zones mirror the long-press action on their respective button pills.
 - Flicks fire the short-press grade step ×3; in project mode (READY/BREAK) flicks are a no-op
   (project cycling is single-step only).
-- At 35 logged routes (`ROUTE_LIMIT`), START is silently refused (the dedicated LIMIT screen was
-  cut in the resident diet) — save & restart to log more.
+- At 35 **live** routes (`ROUTE_LIMIT`), START is silently refused (the dedicated LIMIT screen was
+  cut in the resident diet). The cap gates the un-folded tail only: **pausing the workout folds the
+  tail** into the RAM aggregate and frees all 35 slots — pause once and keep climbing.
 
 ---
 
@@ -68,14 +69,15 @@ until a new editable tail route exists.
 | `active.html`       | CLIMB / BREAK cluster                                      | Workout        |
 | `setup.html`        | Grade-system setup                                         | Config         |
 | `saving.html`       | Near-empty pause/end de-load screen                        | Pause / end    |
-| `migration.html`    | Minimal, input-locked storage-migration screen              | Migration launch |
 | `ext10.js`          | Route end + already-warm save-as-project operation          | On SEND/FAIL   |
-| `ext11.js`          | Native stats/project RMW writer                             | Workout end    |
+| `ext11.js`          | Native stats/project RMW writer + fold-gated legacy cleanup (v3.02, read-back-guarded) | Workout end    |
+| `ext12.js`          | Legacy slot seed for a migration-pending session (staged tick; f12-cached for the SETUP dwell) | Legacy enable |
 | `ext13.js`          | Native destination-system project preload                  | System switch  |
+| `ext15.js`          | Numeric-path working-array merge (END-FOLD)                | First END after a numeric legacy install |
 | `ext14.js`          | Retired save-as-project satellite (kept as a source artifact; no runtime caller) | Never |
-| `ext16.js`          | Live-2.82 → canonical v3 one-write migration                | Migration launch only |
-| `ext17.js`          | Numeric v1/v2 → canonical v3 one-write migration            | Migration launch only |
-| `ext18.js`          | All-system grade-name table for migration rows              | Migration launch only |
+| `ext16.js`          | Live-2.82 → canonical v3 converter (string OR absent stats root) | First END after a 2.82 install (END-FOLD) |
+| `ext17.js`+`ext19.js` | Numeric v1/v2 → canonical v3 converter pair              | First END after a numeric legacy install |
+| `ext18.js`          | All-system grade-name table for adopted Companion rows      | Fold END only |
 | `ext21.js`          | EDIT-overlay actions — result cycle, DEL execution          | On EDIT press  |
 | `ext22.js`          | Generated publish satellite — all output writes (see `tools/gen-out-idx.js`) | Every tick |
 | `ext25.js`          | Session-summary row builder (Sends/Routes, Highest Send, …) | Pause / end    |
@@ -103,12 +105,16 @@ the route arrays can be freed early; it never touches storage.
   dirty bits (`psDirty` = project-slot stats, `slotsDirty` = slot grade
   config changed on the watch,
   `sysDirty` = grade-system choice, persisted even on a routeless session).
-- **Storage migration** — live 2.82 and numeric v1/v2 stores get a dedicated, input-locked
-  `migration.html` launch. `ext16` or `ext17` reads the legacy roots in paced callbacks, builds the
-  complete v3 container in RAM, and performs exactly one `setObject("climbProjStats", …)`. There are
-  no per-system checkpoints or cleanup writes. If that sole write fails, the legacy source remains
-  restartable. After a successful reread, SETUP opens automatically in the same launch. Normal starts
-  and ends never parse migration code or access the compatibility roots.
+- **Storage migration (END-FOLD)** — a legacy store (2.82 string/absent-stats, or numeric v1/v2)
+  only arms `migPend` at the drain; the session runs fully live on a staged read-only slot seed
+  (`ext12`, derived from `stats.system` or `watchSetup.sys`). The FIRST finished session folds the
+  legacy roots → complete v3 container in RAM (`ext16`, or `ext17`+`ext19`) and commits it in one
+  `setObject`. A failed fold leaves the legacy bytes untouched and retries at the next END.
+  **v3.02:** after the canonical write, `ext11` re-reads the container (read-back guard — a silently
+  dropped write must never be followed by legacy erasure) and then empties the 2.82 roots
+  (`climbRoutes`→`[]`, `watchSetup`→`{}`, `stats`→`{}`; probe-first, absent keys never materialized,
+  throw-silent) — a permanent store shrink, since every LS op allocates a whole-file buffer.
+  Normal starts and ends never parse migration code.
 - **`climbProjStats`**: canonical v3 container. `v`, `g`, and `u` hold schema/settings;
   `s0`–`s9` hold lifetime aggregates and `p0`–`p9` hold project vectors.
 - **`p<sys>`**: compact project-stat vector for one grade system
@@ -175,8 +181,8 @@ and don't count against the startup budget — but `main.js` bytecode is RESIDEN
 ~133 KB three-app JS heap, and that residency is what decides whether the pool sits at a
 99 % warn baseline (proven 2026-07-03: 8.2 KB resident = warns/evicts/end-stalls; ≤7.1 KB = clean).
 
-Current footprint (q-display minifier, v3.0):
-- `main.js` minified/resident: 6 894 B
+Current footprint (q-display minifier, v3.02):
+- `main.js` minified/resident: 6 944 B
 - `ext22.js` (generated publish satellite, parsed once per enable): 1 455 B (cap 1 600 B)
 - runtime route satellite: `ext10` (route commit plus warm save-as-project operation)
 
@@ -188,7 +194,7 @@ write, which is the path that fails first under 3-app memory pressure. Grow-rewr
 deterministic storm class, so the store is under a growth freeze (`< 2 100 B`, asserted in
 `tools/tests/stats-endwrite-equiv.js`).
 
-Shipped store: **648 B**. All ten `p<sys>` project vectors are declared with only an empty index-20
+Shipped seed (`data.json`): **244 B**. All ten `p<sys>` project vectors are declared with only an empty index-20
 Companion row; `fillSlots` defaults absent stats indices (`0` for 0–14, `-1` for 15–19). The executable
 storage proof materializes all 50 slots and all ten readable rows while migration still commits the
 whole result in one write and lands the full-history fixture below 2 100 B.


### PR DESCRIPTION
- README: v3.02 title/badge; migration section rewritten to END-FOLD + v3.02
  read-back-guarded cleanup (migration.html and the paced-callback launch are
  long gone); ext table gains ext12/ext15/ext19, drops migration.html; the
  35-route note now says PAUSE frees the slots (not save & restart); footprint
  6944 B, seed 244 B.
- CHANGELOG: v3.0 / v3.01 / v3.02 entries added (latest was still v2.0),
  incl. the field-incident root causes and the 2.82-never-saved finding.
- APPSTORE: user copy-edits + new "Long sessions: pausing and the 35-route
  limit" section (silent refusal stated honestly); typo fixes.

GitHub releases v3.01 + v3.02 published alongside (v3.02 = Latest).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
