### PR TITLE
feat: remove the flick gesture (±3 grade step) — -79 B resident, -259 B built (v3.03)

### DIFF
--- a/APPSTORE.md
+++ b/APPSTORE.md
@@ -70,7 +70,7 @@ Tap ↑/↓, hold ↑/↓/MID; touch mirrors the buttons.
 - **EDIT** — tap: grade / move slot · MID hold: SEND→FAIL→DEL · ↓ hold: previous route · ↑ hold: exit
 - **PROJ-SETUP** — tap: slot grade / OFF · ↓ hold: next slot · ↑ hold: exit
 
-Flick ↑/↓ = ±3 grades (free mode) · MID tap = Suunto's screen scroll.
+MID tap = Suunto's screen scroll.
 
 ## Feedback
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ entering or leaving them swaps nothing:
 ### Per-screen button matrix
 
 Physical buttons: `mid-short` is OS-reserved. Events — up-short/down-short = grade nudges,
-up-long/down-long/mid-long = actions, flick-up/down = quick (×3) grade step.
+up-long/down-long/mid-long = actions.
 
 | Screen    | Up short            | Down short          | Mid long             | Up long                     | Down long            |
 |-----------|---------------------|---------------------|----------------------|-----------------------------|----------------------|
@@ -52,8 +52,6 @@ until a new editable tail route exists.
 - `mid-short` is OS-reserved (scrolls Suunto's native activity screens).
 - `down-long` commits / advances forward.
 - Touch tap-zones mirror the long-press action on their respective button pills.
-- Flicks fire the short-press grade step ×3; in project mode (READY/BREAK) flicks are a no-op
-  (project cycling is single-step only).
 - At 35 **live** routes (`ROUTE_LIMIT`), START is silently refused (the dedicated LIMIT screen was
   cut in the resident diet). The cap gates the un-folded tail only: **pausing the workout folds the
   tail** into the RAM aggregate and frees all 35 slots — pause once and keep climbing.

--- a/active.html
+++ b/active.html
@@ -1,6 +1,4 @@
-<uiView onFlickUp="ev(7)"
-        onFlickDown="ev(8)"
-        onLoad="
+<uiView onLoad="
           var M=Math.floor,S=-1,lock=0;
           function dG(x){if(x<0)return'--';var s=M(x/100),i=x%100;if(i>=50)return'OFF';if(s===0)return(3+M(i/6))+'abc'.charAt(M(i/2)%3)+(i%2?'+':'');if(s===1){var u=(i-2)%3;return i<2?'4'+(i?'+':''):''+(5+M((i-2)/3))+(u===0?'-':u===2?'+':'');}if(s===2)return i<5?'5.'+(i+5):'5.'+(10+M((i-5)/4))+'abcd'.charAt((i-5)%4);if(s===3)return(4+M(i/3))+'abc'.charAt(i%3);if(s===4)return i?'V'+(i-1):'VB';if(s===5)return(4+M(i/6))+'ABC'.charAt(M(i/2)%3)+(i%2?'+':'');if(s===6)return'WI'+(i?3+M((i-1)/2):2)+(i&amp;&amp;(i-1)%2?'+':'');if(s===7)return'M'+(i+1);return s===8?'Set':'Lap';}
           function tm(x){return M(x/60)+&quot;'&quot;+('0'+M(x%60)).slice(-2)}

--- a/main.js
+++ b/main.js
@@ -564,11 +564,7 @@ function onEvent(_input, output, eventId) {
   skipP = 0;  // any press cancels the pending auto-skip — the user is using the SETUP screen
   if (frDirty && (eventId === 4 || eventId === 6)) return;
   if (dwell && eventId === 6 && state === 1) return;
-  var dy = eventId === 1 ? 1 : eventId === 2 ? -1 : 0;
-  if (state === 0 || state === 1 || state === 2) {
-    if (eventId === 7) dy = 3;
-    else if (eventId === 8) dy = -3;
-  } else if (eventId === 7 || eventId === 8) return;
+  var dy = eventId === 1 ? 1 : eventId === 2 ? -1 : 0;  // flick feature removed (3.03): eids 7/8 no longer exist — no bindings emit them
   if (state === 0) evReady(output, eventId, dy);
   else if (state === 1) { if (eventId === 5 || eventId === 6) finishRoute(eventId === 6 ? 1 : 0, output); }
   else if (state === 2) evBreak(output, eventId, dy);

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
  "name": "Climb Log",
  "description": "Track your progress on rock & ice.",
- "version": "3.02",
+ "version": "3.03",
  "author": "skyfi",
- "modificationTime": 1784559767,
+ "modificationTime": 1784564276,
  "type": "feature",
  "usage": "workout",
  "in": [

--- a/ready.html
+++ b/ready.html
@@ -1,6 +1,4 @@
-<uiView onFlickUp="ev(7)"
-        onFlickDown="ev(8)"
-        onLoad="
+<uiView onLoad="
           var lock=0,vs=0,M=Math.floor;
           function dG(x){if(x<0)return'--';var s=M(x/100),i=x%100;if(i>=50)return'OFF';if(s===0)return(3+M(i/6))+'abc'.charAt(M(i/2)%3)+(i%2?'+':'');if(s===1){var u=(i-2)%3;return i<2?'4'+(i?'+':''):(5+M((i-2)/3))+(u===0?'-':u===2?'+':'');}if(s===2)return i<5?'5.'+(i+5):'5.'+(10+M((i-5)/4))+'abcd'.charAt((i-5)%4);if(s===3)return(4+M(i/3))+'abc'.charAt(i%3);if(s===4)return i?'V'+(i-1):'VB';if(s===5)return(4+M(i/6))+'ABC'.charAt(M(i/2)%3)+(i%2?'+':'');if(s===6)return'WI'+(i?3+M((i-1)/2):2)+(i&&(i-1)%2?'+':'');if(s===7)return'M'+(i+1);return s===8?'Set':'Lap';}
           function mS(x){setText('#rm',x>99?'ROUTE EDIT':x<-99?'PROJECT EDIT':x<0?'PROJECT MODE':'ROUTE MODE');x%=100;return x>0?'#'+x:'P'+(-x)}

--- a/setup.html
+++ b/setup.html
@@ -1,6 +1,4 @@
-<uiView onFlickUp="ev(7)"
-        onFlickDown="ev(8)"
-        onLoad="
+<uiView onLoad="
           var M=Math.floor,SN='French Sport,UIAA Sport,YDS Sport,British Trad,V-Scale,Font Boulder,Ice (WI),Mixed (M),Hangboard,Scrambling'.split(',');
           // SETUP only ever previews the DEFAULT grade of the selected system (main.js state-4 sets
           // gradeV=encGrade(DEFAULT_IDX[gradeSystem])), so the 10 samples are precomputed here as a flat

--- a/tools/tests/dispatch-equiv.js
+++ b/tools/tests/dispatch-equiv.js
@@ -344,7 +344,7 @@ var SCENARIOS = [
     ['ui'], ['load'], T(2),
     ['ev', 1], ['ev', 1], ['ev', 2],          // system cycling in SETUP (dy)
     ['ev', 6], T(2),                          // confirm -> READY (+ pendSlots tick)
-    ['ev', 1], ['ev', 7], ['ev', 2],          // free-mode grade steps incl. ±3
+    ['ev', 1], ['ev', 2],                     // free-mode grade steps (flick eids removed 3.03)
     ['ev', 6], T(3),                          // START -> CLIMB
     ['ev', 6], T(2),                          // SEND -> BREAK -> commit tick
     ['ev', 1], ['ev', 2],                     // BREAK grade corrections
@@ -412,17 +412,14 @@ var SCENARIOS = [
   )],
   ['EXT overlay edges: system 9 (L=1), empty editor, eid7/8 in 4/5/6, OFF-sentinel slot, no-slot toggle', FRESH, seq(
     ['ui'], ['load'], ['sum'], T(1),
-    ['ev', 7], ['ev', 8],                     // eid7/8 in SETUP (state 4) -> must return
     ['ev', 2], T(1),                          // dy -1 -> system 9 (GRADE_LENS 1, sentinel 950 band)
     ['ev', 6], T(2),                          // confirm -> READY + pendSlots drain (all p9_* undefined)
-    ['ev', 1], ['ev', 7], ['ev', 2],          // stepG with L=1 (always 0) incl. +-3 flick
+    ['ev', 1], ['ev', 2],                     // stepG with L=1 (always 0)
     ['ev', 5], T(2),                          // EDIT overlay EMPTY (routesA.length 0) + pendE parse tick
-    ['ev', 7], ['ev', 8],                     // eid7/8 in EDIT (state 5) -> must return
     ['ev', 1], ['ev', 2], ['ev', 4],          // empty-editor no-ops
     ['ev', 6], T(1),                          // empty-editor exit via eid6
     ['ev', 4], T(1),                          // toggleMode inline with ZERO configured slots -> climbMode stays 1
     ['ev', 5], T(1),                          // proj-setup overlay: slot 1 unconfigured -> slotG OFF sentinel (950)
-    ['ev', 7], ['ev', 8],                     // eid7/8 in PROJ-SETUP (state 6) -> must return
     ['ev', 6],                                // pStep -> slot 2 (also OFF)
     ['ev', 1], T(1),                          // dy on OFF slot: -1 -> 0 (configured), slotsDirty
     ['ev', 5], T(1),                          // exit overlay
@@ -520,7 +517,6 @@ var SCENARIOS = [
     ['ev', 6], T(1),                    // confirm default system -> READY
     ['ev', 5],                          // EDIT with 0 routes (pendE=1)
     T(1),
-    ['ev', 7], ['ev', 8],               // state 5: early return
     ['ev', 1], ['ev', 2], ['ev', 4],    // empty-editor swallow
     ['ev', 6],                          // len 0 -> exit
     T(1),
@@ -532,19 +528,17 @@ var SCENARIOS = [
   )],
   ['FLT G eid7/8 BREAK/SETUP + ext14 throw', RETURN, seq(
     ['ui'], ['load'], T(2),
-    ['ev', 7], ['ev', 8],               // READY free ±3
-    ['ev', 6], T(2), ['ev', 7], ['ev', 8], ['ev', 6], T(1),  // CLIMB swallow, SEND, commit
-    ['ev', 7], ['ev', 8],               // BREAK free ±3 (wGrade on committed route + recalcBse)
+    ['ev', 6], T(2), ['ev', 6], T(1),   // CLIMB, SEND, commit
     ['fault', '14', 1],
     ['ev', 4],                          // saveAsProject inline throws -> no-op
     ['fault', '14', 0],
     ['ev', 4],                          // succeeds -> project mode, READY
     T(1),
-    ['ev', 5], ['ev', 7], ['ev', 8],    // proj-setup overlay, eid7/8 swallowed
+    ['ev', 5],                          // proj-setup overlay
     ['ev', 1], ['ev', 6], ['ev', 5],    // slot step, next slot, exit
     T(1),
     ['ev', 6], T(2), ['ev', 6], T(1),   // slot climb + SEND
-    ['ev', 1], ['ev', 7],               // BREAK project: cycle +1, ±3 refused
+    ['ev', 1],                          // BREAK project: cycle +1
     ['ev', 6], T(1),
     ['end'], ['sum']
   )],
@@ -611,7 +605,7 @@ var SCENARIOS = [
     ['ui'], ['load'],
     ['ev', 1], ['ev', 2],               // SETUP dy while stone-cold (cancels skipP; FBW crown vs oracle targeted writes)
     ['ev', 6],                          // confirm -> READY mount, still cold (no sysChg: plain confirm)
-    ['ev', 1], ['ev', 7],               // READY grade flicks while cold — fluidity through the cold window
+    ['ev', 1], ['ev', 2], ['ev', 1],    // READY grade presses while cold — fluidity through the cold window
     T(2),                               // stager tick -> warm + full republish
     ['ev', 6], T(2), ['ev', 6], T(2),   // route 1 warm
     ['end'], ['sum']
@@ -619,7 +613,7 @@ var SCENARIOS = [
   ['S5 FLT M permanent ext22 parse fail: whole session on the FBW crown (states 0/1/2/4 only)', RETURN, seq(
     ['fault', '22', 999],
     ['ui'], ['load'], T(2),             // stager throws (capped) -> permanent cold
-    ['ev', 1], ['ev', 7], ['ev', 2],    // READY free-mode flicks stay fluid
+    ['ev', 1], ['ev', 2], ['ev', 1],    // READY free-mode presses stay fluid
     ['ev', 4], T(1),                    // project toggle (slot 1) — FBW proj-branch crown
     ['ev', 1], ['ev', 2],               // cycleSlot ±1 cold
     ['ev', 4],                          // back to free mode


### PR DESCRIPTION
Flick up/down (eids 7/8) is gone: template bindings removed from all three
screens, the onEvent dy-mapping + overlay guards deleted (the eids can no
longer arrive). Grade stepping stays on press/tap/hold as before.

main.js resident 6944 -> 6865 B — below the v3.0 diet floor (6894); each of
setup/ready/active sheds 60 B of mount payload. dispatch-equiv oracle streams
updated (13 flick steps removed — both sides replay identical streams, so the
frozen-oracle comparison stays sound); APPSTORE + README flick mentions
dropped. Full suite + build trias green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
